### PR TITLE
Respect reduced motion in design system animations

### DIFF
--- a/public/index/css/design-system.css
+++ b/public/index/css/design-system.css
@@ -1,0 +1,209 @@
+/* Animation classes with reduced motion fallbacks */
+
+/* Non-animated defaults */
+.fade-in,
+.fade-out,
+.slide-up,
+.slide-down,
+.slide-left,
+.slide-right,
+.scale-in,
+.scale-out,
+.rotate {
+  animation: none;
+}
+
+.fade-in {
+  opacity: 1;
+}
+
+.fade-out {
+  opacity: 0;
+}
+
+.slide-up,
+.slide-down {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.slide-left,
+.slide-right {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.scale-in {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.scale-out {
+  transform: scale(0.9);
+  opacity: 0;
+}
+
+.rotate {
+  transform: none;
+}
+
+.loading {
+  position: relative;
+  pointer-events: none;
+}
+
+.loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1rem;
+  height: 1rem;
+  margin: -0.5rem 0 0 -0.5rem;
+  border: 2px solid var(--gray-300);
+  border-top-color: var(--primary-blue-500);
+  border-radius: 50%;
+  animation: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .fade-in {
+    animation: fadeIn var(--transition-normal, 250ms) ease-in-out;
+  }
+
+  .fade-out {
+    animation: fadeOut var(--transition-normal, 250ms) ease-in-out;
+  }
+
+  .slide-up {
+    animation: slideUp var(--transition-normal, 250ms) ease-out;
+  }
+
+  .slide-down {
+    animation: slideDown var(--transition-normal, 250ms) ease-out;
+  }
+
+  .slide-left {
+    animation: slideLeft var(--transition-normal, 250ms) ease-out;
+  }
+
+  .slide-right {
+    animation: slideRight var(--transition-normal, 250ms) ease-out;
+  }
+
+  .scale-in {
+    animation: scaleIn var(--transition-normal, 250ms) ease-out;
+  }
+
+  .scale-out {
+    animation: scaleOut var(--transition-normal, 250ms) ease-out;
+  }
+
+  .rotate {
+    animation: rotate var(--transition-slow, 350ms) linear infinite;
+  }
+
+  .loading::after {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes slideUp {
+    from {
+      transform: translateY(20px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  @keyframes slideDown {
+    from {
+      transform: translateY(-20px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  @keyframes slideLeft {
+    from {
+      transform: translateX(20px);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+
+  @keyframes slideRight {
+    from {
+      transform: translateX(-20px);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+
+  @keyframes scaleIn {
+    from {
+      transform: scale(0.9);
+      opacity: 0;
+    }
+    to {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes scaleOut {
+    from {
+      transform: scale(1);
+      opacity: 1;
+    }
+    to {
+      transform: scale(0.9);
+      opacity: 0;
+    }
+  }
+
+  @keyframes rotate {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add design-system.css with animation utilities
- include non-animated defaults and only run keyframes when user does not prefer reduced motion

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68916376fc1883289b18f922059a802b