### PR TITLE
Disable Node integration for splash screen

### DIFF
--- a/main.js
+++ b/main.js
@@ -472,7 +472,7 @@ function createSplashWindow() {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       enableRemoteModule: false,
-      nodeIntegration: true,
+      nodeIntegration: false,
     },
     icon: path.join(__dirname, "assets/icons/ico/icon-exe.ico"),
   });

--- a/preload.js
+++ b/preload.js
@@ -3,6 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   sendLoginAttempt: (credentials) => ipcRenderer.send('login-attempt', credentials),
-  onLoginResponse: (callback) => ipcRenderer.on('login-response', (event, response) => callback(response)),
-  onUserData: (callback) => ipcRenderer.on('user-data', (event, userData) => callback(userData))
+  onLoginResponse: (callback) => ipcRenderer.once('login-response', (_event, response) => callback(response)),
+  onUserData: (callback) => ipcRenderer.on('user-data', (_event, userData) => callback(userData))
 });


### PR DESCRIPTION
## Summary
- Turn off Node integration for splash window.
- Bridge login APIs through `preload.js` using `contextBridge`.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68914f63cef083288796c7bebfd0faa5