### PR TITLE
Rename recipient columns and update queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Records Management System
+
+## Migration
+
+Legacy installations may use the misspelled columns `reciepient` and `recieved_date` in the `entries_tbl` table.
+Run the migration script to rename them to `recipient` and `received_date`:
+
+```
+node database/migrations/rename_recipient_columns.js
+```
+
+Make sure to back up your database before running the script. The application accepts either the old or new field names in request payloads during the transition period.
+

--- a/database/migrations/rename_recipient_columns.js
+++ b/database/migrations/rename_recipient_columns.js
@@ -1,0 +1,51 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.resolve(__dirname, '../recordsmgmtsys.db');
+const db = new sqlite3.Database(dbPath, (err) => {
+  if (err) {
+    console.error('Unable to open database:', err.message);
+    process.exit(1);
+  }
+});
+
+function columnExists(columns, name) {
+  return columns.some(col => col.name === name);
+}
+
+db.serialize(() => {
+  db.all("PRAGMA table_info(entries_tbl);", (err, columns) => {
+    if (err) {
+      console.error('Error fetching table info:', err.message);
+      db.close();
+      return;
+    }
+
+    const migrations = [];
+
+    if (columnExists(columns, 'reciepient') && !columnExists(columns, 'recipient')) {
+      migrations.push(["ALTER TABLE entries_tbl RENAME COLUMN reciepient TO recipient;", 'reciepient -> recipient']);
+    }
+
+    if (columnExists(columns, 'recieved_date') && !columnExists(columns, 'received_date')) {
+      migrations.push(["ALTER TABLE entries_tbl RENAME COLUMN recieved_date TO received_date;", 'recieved_date -> received_date']);
+    }
+
+    (function run(i) {
+      if (i >= migrations.length) {
+        console.log('Migration complete.');
+        db.close();
+        return;
+      }
+      const [sql, msg] = migrations[i];
+      db.run(sql, (err) => {
+        if (err) {
+          console.error(`Failed to rename column (${msg}):`, err.message);
+        } else {
+          console.log(`Renamed column (${msg}).`);
+        }
+        run(i + 1);
+      });
+    })(0);
+  });
+});

--- a/main.js
+++ b/main.js
@@ -187,23 +187,36 @@ function startServer() {
 
   // ADD FILE TO TABLE
   app.post('/api/add-file', (req, res) => {
-    const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
+    const {
+      entry_date,
+      file_number,
+      subject,
+      officer_assigned,
+      status,
+      received_date,
+      date_sent,
+      file_type,
+      recipient,
+      description,
+      reciepient,
+      recieved_date
+    } = req.body;
 
     // Check only for required fields
     if (!entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
-    // Use null for optional fields if not provided
-    const reciepientValue = reciepient || null;
-    const recievedDateValue = recieved_date || null;
+    // Backward compatibility with older payload keys
+    const recipientValue = recipient || reciepient || null;
+    const receivedDateValue = received_date || recieved_date || null;
     const descriptionValue = description || null;
 
     const query = `
-    INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, reciepient, description, status)
+    INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, received_date, date_sent, file_type, recipient, description, status)
     VALUES (?, 'File', ?, ?, ?, ?, ?, ?, ?, ?, ?);
   `;
-    db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, reciepientValue, descriptionValue, status], function (err) {
+    db.run(query, [entry_date, file_number, subject, officer_assigned, receivedDateValue, date_sent, file_type, recipientValue, descriptionValue, status], function (err) {
       if (err) {
         console.error("Error inserting new file:", err.message);
         return res.status(500).json({ error: err.message });
@@ -214,18 +227,20 @@ function startServer() {
 
 // UPDATE FILE IN TABLE
 app.post('/api/update-file', (req, res) => {
-  const { 
+  const {
     entry_id,
     entry_date,
     file_number,
     subject,
     officer_assigned,
     status,
-    recieved_date,    // Correct spelling here: received_date
+    received_date,
     date_sent,
-    reciepient,        // Correct spelling here
+    recipient,
     file_type,
-    description
+    description,
+    reciepient,
+    recieved_date
   } = req.body;
 
   // Check only for required fields
@@ -234,13 +249,13 @@ app.post('/api/update-file', (req, res) => {
   }
 
   // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;  // Correct spelling here
-  const recievedDateValue = recieved_date || null;  // Correct spelling here
+  const recipientValue = recipient || reciepient || null;
+  const receivedDateValue = received_date || recieved_date || null;
   const descriptionValue = description || null;
 
   const query = `
     UPDATE entries_tbl
-    SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, date_sent = ?, reciepient = ?, file_type = ?, description = ?, status = ?
+    SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, received_date = ?, date_sent = ?, recipient = ?, file_type = ?, description = ?, status = ?
     WHERE entry_id = ? AND entry_category = 'File';
   `;
 
@@ -249,9 +264,9 @@ app.post('/api/update-file', (req, res) => {
     file_number,
     subject,
     officer_assigned,
-    recievedDateValue,  // Corrected: received date
+    receivedDateValue,
     date_sent,
-    reciepientValue,     // Corrected: recipient
+    recipientValue,
     file_type,
     descriptionValue,
     status,
@@ -285,10 +300,22 @@ app.post('/api/update-file', (req, res) => {
 
   // ADD LETTER TO TABLE
   app.post('/api/add-letter', (req, res) => {
-    const { entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
+    const {
+      entry_date,
+      file_number,
+      subject,
+      officer_assigned,
+      status,
+      received_date,
+      letter_date,
+      letter_type,
+      folio_number,
+      description,
+      recieved_date
+    } = req.body;
 
     // Check only for required fields
-    if (!entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
+    if (!entry_date || !file_number || !subject || !officer_assigned || !status || !(received_date || recieved_date) || !letter_date || !letter_type) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
@@ -297,10 +324,10 @@ app.post('/api/update-file', (req, res) => {
     const descriptionValue = description || null;
 
     const query = `
-      INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folio_number, description, status)
+      INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, received_date, letter_date, letter_type, folio_number, description, status)
       VALUES (?, 'Letter', ?, ?, ?, ?, ?, ?, ?, ?, ?);
   `;
-    db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status], function (err) {
+    db.run(query, [entry_date, file_number, subject, officer_assigned, received_date || recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status], function (err) {
       if (err) {
         console.error("Error inserting new letter:", err.message);
         return res.status(500).json({ error: err.message });
@@ -312,10 +339,23 @@ app.post('/api/update-file', (req, res) => {
 
   // UPDATE LETTER IN TABLE
   app.post('/api/update-letter', (req, res) => {
-    const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
+    const {
+      entry_id,
+      entry_date,
+      file_number,
+      subject,
+      officer_assigned,
+      status,
+      received_date,
+      letter_date,
+      letter_type,
+      folio_number,
+      description,
+      recieved_date
+    } = req.body;
 
     // Check only for required fields
-    if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
+    if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !(received_date || recieved_date) || !letter_date || !letter_type) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
@@ -325,10 +365,10 @@ app.post('/api/update-file', (req, res) => {
 
     const query = `
       UPDATE entries_tbl
-      SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, letter_date = ?, letter_type = ?, folio_number = ?, description = ?, status = ?
+      SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, received_date = ?, letter_date = ?, letter_type = ?, folio_number = ?, description = ?, status = ?
       WHERE entry_id = ? AND entry_category = 'Letter';
   `;
-    db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
+    db.run(query, [entry_date, file_number, subject, officer_assigned, received_date || recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
       if (err) {
         console.error("Error updating letter:", err.message);
         return res.status(500).json({ error: err.message });

--- a/server.js
+++ b/server.js
@@ -115,23 +115,36 @@ app.get('/api/get-files', (req, res) => {
 
 // ADD FILE TO TABLE
 app.post('/api/add-file', (req, res) => {
-  const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
+  const {
+    entry_date,
+    file_number,
+    subject,
+    officer_assigned,
+    status,
+    received_date,
+    date_sent,
+    file_type,
+    recipient,
+    description,
+    reciepient,
+    recieved_date
+  } = req.body;
 
   // Check only for required fields
   if (!entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
     return res.status(400).json({ error: 'Missing required fields' });
   }
 
-  // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;
-  const recievedDateValue = recieved_date || null;
+  // Backward compatibility with older payload keys
+  const recipientValue = recipient || reciepient || null;
+  const receivedDateValue = received_date || recieved_date || null;
   const descriptionValue = description || null;
 
   const query = `
-    INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, reciepient, description, status)
+    INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, received_date, date_sent, file_type, recipient, description, status)
     VALUES (?, 'File', ?, ?, ?, ?, ?, ?, ?, ?, ?);
   `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, reciepientValue, descriptionValue, status], function (err) {
+  db.run(query, [entry_date, file_number, subject, officer_assigned, receivedDateValue, date_sent, file_type, recipientValue, descriptionValue, status], function (err) {
     if (err) {
       console.error("Error inserting new file:", err.message);
       return res.status(500).json({ error: err.message });
@@ -142,24 +155,39 @@ app.post('/api/add-file', (req, res) => {
 
 // UPDATE FILE IN TABLE
 app.post('/api/update-file', (req, res) => {
-  const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, reciepient, file_type, folio_number, description } = req.body;
+  const {
+    entry_id,
+    entry_date,
+    file_number,
+    subject,
+    officer_assigned,
+    status,
+    received_date,
+    date_sent,
+    recipient,
+    file_type,
+    folio_number,
+    description,
+    reciepient,
+    recieved_date
+  } = req.body;
 
   // Check only for required fields
   if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
     return res.status(400).json({ error: 'Missing required fields' });
   }
 
-  // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;
-  const recievedDateValue = folio_number || null;
+  // Backward compatibility with older payload keys
+  const recipientValue = recipient || reciepient || null;
+  const receivedDateValue = received_date || recieved_date || null;
   const descriptionValue = description || null;
 
   const query = `
     UPDATE entries_tbl
-    SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, date_sent = ?, reciepient = ?, file_type = ?, folio_number = ?, description = ?, status = ?
+    SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, received_date = ?, date_sent = ?, recipient = ?, file_type = ?, folio_number = ?, description = ?, status = ?
     WHERE entry_id = ? AND entry_category = 'File';
   `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, recievedDateValue,reciepientValue, descriptionValue, status, entry_id], function (err) {
+  db.run(query, [entry_date, file_number, subject, officer_assigned, receivedDateValue, date_sent, recipientValue, file_type, folio_number || null, descriptionValue, status, entry_id], function (err) {
     if (err) {
       console.error("Error updating file:", err.message);
       return res.status(500).json({ error: err.message });
@@ -187,10 +215,22 @@ app.post('/api/update-file', (req, res) => {
 
 // ADD LETTER TO TABLE
 app.post('/api/add-letter', (req, res) => {
-  const { entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
+  const {
+    entry_date,
+    file_number,
+    subject,
+    officer_assigned,
+    status,
+    received_date,
+    letter_date,
+    letter_type,
+    folio_number,
+    description,
+    recieved_date
+  } = req.body;
 
   // Check only for required fields
-  if (!entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
+  if (!entry_date || !file_number || !subject || !officer_assigned || !status || !(received_date || recieved_date) || !letter_date || !letter_type) {
       return res.status(400).json({ error: 'Missing required fields' });
   }
 
@@ -199,10 +239,10 @@ app.post('/api/add-letter', (req, res) => {
   const descriptionValue = description || null;
 
   const query = `
-      INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folio_number, description, status)
+      INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, received_date, letter_date, letter_type, folio_number, description, status)
       VALUES (?, 'Letter', ?, ?, ?, ?, ?, ?, ?, ?, ?);
   `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status], function (err) {
+  db.run(query, [entry_date, file_number, subject, officer_assigned, received_date || recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status], function (err) {
       if (err) {
           console.error("Error inserting new letter:", err.message);
           return res.status(500).json({ error: err.message });
@@ -214,10 +254,23 @@ app.post('/api/add-letter', (req, res) => {
 
   // UPDATE LETTER IN TABLE
 app.post('/api/update-letter', (req, res) => {
-  const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
+  const {
+    entry_id,
+    entry_date,
+    file_number,
+    subject,
+    officer_assigned,
+    status,
+    received_date,
+    letter_date,
+    letter_type,
+    folio_number,
+    description,
+    recieved_date
+  } = req.body;
 
   // Check only for required fields
-  if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
+  if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !(received_date || recieved_date) || !letter_date || !letter_type) {
       return res.status(400).json({ error: 'Missing required fields' });
   }
 
@@ -227,10 +280,10 @@ app.post('/api/update-letter', (req, res) => {
 
   const query = `
       UPDATE entries_tbl
-      SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, letter_date = ?, letter_type = ?, folio_number = ?, description = ?, status = ?
+      SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, received_date = ?, letter_date = ?, letter_type = ?, folio_number = ?, description = ?, status = ?
       WHERE entry_id = ? AND entry_category = 'Letter';
   `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
+  db.run(query, [entry_date, file_number, subject, officer_assigned, received_date || recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
       if (err) {
           console.error("Error updating letter:", err.message);
           return res.status(500).json({ error: err.message });

--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -152,8 +152,8 @@ function populateFileModalFields(data) {
     // File type, date sent, and recipient input fields
     $('#file_type').val(data.file_type);
     $('#date_sent').val(data.date_sent);
-    $('#reciepient_name').val(data.reciepient);
-    $('#recieved_date').val(data.recieved_date);  // Ensure this field is correctly populated
+    $('#recipient').val(data.recipient);
+    $('#received_date').val(data.received_date);  // Ensure this field is correctly populated
 
     // Additional fields
     $('#description').val(data.description);
@@ -168,10 +168,10 @@ function getFileFormData() {
         subject: $('#subject').val(),
         officer_assigned: $('#officer_assigned').val(),
         status: $('#status').val(),
-        recieved_date: $('#recieved_date').val(),
+        received_date: $('#received_date').val(),
         date_sent: $('#date_sent').val(),
         file_type: $('#file_type').val(),
-        reciepient: $('#reciepient_name').val(),
+        recipient: $('#recipient').val(),
         description: $('#description').val(),
     };
     return data;
@@ -183,10 +183,10 @@ function clearFileModalFields() {
     $('#file_number').val('');
     $('#subject').val('');
     $('#officer_assigned').val('');
-    $('#recieved_date').val('');
+    $('#received_date').val('');
     $('#date_sent').val('');
     $('#file_type').val('');
-    $('#reciepient').val('');
+    $('#recipient').val('');
     $('#description').val('');
     $('#status').val('');
     $('#fileForm').data('entry_id', null);

--- a/src/partials-public/letter-management/js/letters-renderer.js
+++ b/src/partials-public/letter-management/js/letters-renderer.js
@@ -146,7 +146,7 @@ function populateLetterModalFields(data) {
     $('#file_number').val(data.file_number);
     $('#subject').val(data.subject);
     $('#officer_assigned').val(data.officer_assigned);
-    $('#recieved_date').val(data.recieved_date);
+    $('#received_date').val(data.received_date);
     $('#letter_date').val(data.letter_date);
     $('#letter_type').val(data.letter_type);
     $('#folio_number').val(data.folio_number);
@@ -164,7 +164,7 @@ function getLetterFormData() {
         subject: $('#subject').val(),
         officer_assigned: $('#officer_assigned').val(),
         status: $('#status').val(),
-        recieved_date: $('#recieved_date').val(),
+        received_date: $('#received_date').val(),
         letter_date: $('#letter_date').val(),
         letter_type: $('#letter_type').val(),
         folio_number: $('#folio_number').val() || null,
@@ -177,7 +177,7 @@ function clearLetterModalFields() {
     $('#file_number').val('');
     $('#subject').val('');
     $('#officer_assigned').val('');
-    $('#recieved_date').val('');
+    $('#received_date').val('');
     $('#letter_date').val('');
     $('#letter_type').val('');
     $('#folio_number').val('');

--- a/views/pages/file-management.ejs
+++ b/views/pages/file-management.ejs
@@ -90,8 +90,8 @@
                             </div>
                             <!-- Received Date -->
                             <div class="col-md-6">
-                                <label for="recieved_date" class="form-label">Received Date</label>
-                                <input type="date" class="form-control" id="recieved_date" name="recieved_date">
+                                <label for="received_date" class="form-label">Received Date</label>
+                                <input type="date" class="form-control" id="received_date" name="received_date">
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -113,8 +113,8 @@
                         <div class="row mb-3">
                             <!-- Reciepient Name -->
                             <div class="col-md-6">
-                                <label for="reciepient_name" class="form-label">Reciepient Name</label>
-                                <input type="text" class="form-control" id="reciepient_name" name="reciepient_name"
+                                <label for="recipient" class="form-label">Recipient Name</label>
+                                <input type="text" class="form-control" id="recipient" name="recipient"
                                     placeholder="NULL">
                             </div>
                             <!-- Description -->

--- a/views/pages/letter-management.ejs
+++ b/views/pages/letter-management.ejs
@@ -89,8 +89,8 @@
                             </div>
                             <!-- Received Date -->
                             <div class="col-md-6">
-                                <label for="recieved_date" class="form-label">Received Date</label>
-                                <input type="date" class="form-control" id="recieved_date" name="recieved_date">
+                                <label for="received_date" class="form-label">Received Date</label>
+                                <input type="date" class="form-control" id="received_date" name="received_date">
                             </div>
                         </div>
                         <div class="row mb-3">


### PR DESCRIPTION
## Summary
- add migration script renaming legacy `reciepient`/`recieved_date` columns
- update server, main process and front-end to use `recipient` and `received_date`
- document migration steps for existing deployments

## Testing
- `node database/migrations/rename_recipient_columns.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68914f595ec083289d8b3515305b5a53