### PR TITLE
Fix entries table reload after entry update

### DIFF
--- a/src/partials-public/entries/js/entries-renderer.js
+++ b/src/partials-public/entries/js/entries-renderer.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
             success: function (response) {
                 console.log("Entry updated successfully:", response);
                 $('#entryModal').modal('hide');
-                $('#letters-table').DataTable().ajax.reload(); // Reload table to reflect changes
+                $('#entries-table').DataTable().ajax.reload(); // Reload table to reflect changes
             },
             error: function (xhr, status, error) {
                 console.error("Error updating entry:", error);


### PR DESCRIPTION
## Summary
- Ensure entry updates refresh the entries table and hide the modal

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150c3a1f88328a67a4597e3bb115b