### PR TITLE
fix: rename recipient field

### DIFF
--- a/main.js
+++ b/main.js
@@ -187,7 +187,7 @@ function startServer() {
 
   // ADD FILE TO TABLE
   app.post('/api/add-file', (req, res) => {
-    const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
+    const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, recipient, description } = req.body;
 
     // Check only for required fields
     if (!entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
@@ -195,7 +195,7 @@ function startServer() {
     }
 
     // Use null for optional fields if not provided
-    const reciepientValue = reciepient || null;
+    const recipientValue = recipient || null;
     const recievedDateValue = recieved_date || null;
     const descriptionValue = description || null;
 
@@ -203,7 +203,7 @@ function startServer() {
     INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, reciepient, description, status)
     VALUES (?, 'File', ?, ?, ?, ?, ?, ?, ?, ?, ?);
   `;
-    db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, reciepientValue, descriptionValue, status], function (err) {
+    db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, recipientValue, descriptionValue, status], function (err) {
       if (err) {
         console.error("Error inserting new file:", err.message);
         return res.status(500).json({ error: err.message });
@@ -223,7 +223,7 @@ app.post('/api/update-file', (req, res) => {
     status,
     recieved_date,    // Correct spelling here: received_date
     date_sent,
-    reciepient,        // Correct spelling here
+    recipient,        // Correct spelling here
     file_type,
     description
   } = req.body;
@@ -234,7 +234,7 @@ app.post('/api/update-file', (req, res) => {
   }
 
   // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;  // Correct spelling here
+  const recipientValue = recipient || null;  // Correct spelling here
   const recievedDateValue = recieved_date || null;  // Correct spelling here
   const descriptionValue = description || null;
 
@@ -251,7 +251,7 @@ app.post('/api/update-file', (req, res) => {
     officer_assigned,
     recievedDateValue,  // Corrected: received date
     date_sent,
-    reciepientValue,     // Corrected: recipient
+    recipientValue,     // Corrected: recipient
     file_type,
     descriptionValue,
     status,

--- a/server.js
+++ b/server.js
@@ -115,7 +115,7 @@ app.get('/api/get-files', (req, res) => {
 
 // ADD FILE TO TABLE
 app.post('/api/add-file', (req, res) => {
-  const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
+  const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, recipient, description } = req.body;
 
   // Check only for required fields
   if (!entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
@@ -123,7 +123,7 @@ app.post('/api/add-file', (req, res) => {
   }
 
   // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;
+  const recipientValue = recipient || null;
   const recievedDateValue = recieved_date || null;
   const descriptionValue = description || null;
 
@@ -131,7 +131,7 @@ app.post('/api/add-file', (req, res) => {
     INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, reciepient, description, status)
     VALUES (?, 'File', ?, ?, ?, ?, ?, ?, ?, ?, ?);
   `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, reciepientValue, descriptionValue, status], function (err) {
+  db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, recipientValue, descriptionValue, status], function (err) {
     if (err) {
       console.error("Error inserting new file:", err.message);
       return res.status(500).json({ error: err.message });
@@ -142,7 +142,7 @@ app.post('/api/add-file', (req, res) => {
 
 // UPDATE FILE IN TABLE
 app.post('/api/update-file', (req, res) => {
-  const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, reciepient, file_type, folio_number, description } = req.body;
+  const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, recipient, file_type, folio_number, description } = req.body;
 
   // Check only for required fields
   if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
@@ -150,7 +150,7 @@ app.post('/api/update-file', (req, res) => {
   }
 
   // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;
+  const recipientValue = recipient || null;
   const recievedDateValue = folio_number || null;
   const descriptionValue = description || null;
 
@@ -159,7 +159,7 @@ app.post('/api/update-file', (req, res) => {
     SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, date_sent = ?, reciepient = ?, file_type = ?, folio_number = ?, description = ?, status = ?
     WHERE entry_id = ? AND entry_category = 'File';
   `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, recievedDateValue,reciepientValue, descriptionValue, status, entry_id], function (err) {
+  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, recievedDateValue,recipientValue, descriptionValue, status, entry_id], function (err) {
     if (err) {
       console.error("Error updating file:", err.message);
       return res.status(500).json({ error: err.message });

--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -152,7 +152,7 @@ function populateFileModalFields(data) {
     // File type, date sent, and recipient input fields
     $('#file_type').val(data.file_type);
     $('#date_sent').val(data.date_sent);
-    $('#reciepient_name').val(data.reciepient);
+    $('#recipient_name').val(data.recipient);
     $('#recieved_date').val(data.recieved_date);  // Ensure this field is correctly populated
 
     // Additional fields
@@ -171,7 +171,7 @@ function getFileFormData() {
         recieved_date: $('#recieved_date').val(),
         date_sent: $('#date_sent').val(),
         file_type: $('#file_type').val(),
-        reciepient: $('#reciepient_name').val(),
+        recipient: $('#recipient_name').val(),
         description: $('#description').val(),
     };
     return data;
@@ -186,7 +186,7 @@ function clearFileModalFields() {
     $('#recieved_date').val('');
     $('#date_sent').val('');
     $('#file_type').val('');
-    $('#reciepient').val('');
+    $('#recipient_name').val('');
     $('#description').val('');
     $('#status').val('');
     $('#fileForm').data('entry_id', null);

--- a/views/pages/file-management.ejs
+++ b/views/pages/file-management.ejs
@@ -111,10 +111,10 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <!-- Reciepient Name -->
+                            <!-- Recipient Name -->
                             <div class="col-md-6">
-                                <label for="reciepient_name" class="form-label">Reciepient Name</label>
-                                <input type="text" class="form-control" id="reciepient_name" name="reciepient_name"
+                                <label for="recipient_name" class="form-label">Recipient Name</label>
+                                <input type="text" class="form-control" id="recipient_name" name="recipient_name"
                                     placeholder="NULL">
                             </div>
                             <!-- Description -->


### PR DESCRIPTION
## Summary
- correct recipient input field name in file management view
- update client-side JS to use `recipient_name` and `recipient`
- align server handlers to read `recipient` from requests

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68914e5b52bc83289e64a329357ad670