### PR TITLE
Close database on app exit

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,6 +50,30 @@ const db = new sqlite3.Database(dbPath, (err) => {
     console.log('Connected to the SQLite database at', dbPath);
   }
 });
+
+let dbClosed = false;
+const closeDatabase = () => {
+  if (dbClosed) return;
+  db.close((err) => {
+    if (err) {
+      console.error('Error closing database:', err.message);
+    } else {
+      console.log('Database connection closed.');
+    }
+  });
+  dbClosed = true;
+};
+
+app.on('quit', closeDatabase);
+process.on('SIGINT', () => {
+  closeDatabase();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  closeDatabase();
+  process.exit(0);
+});
+process.on('exit', closeDatabase);
 // Start Express server
 function startServer() {
   const app = express();

--- a/server.js
+++ b/server.js
@@ -18,6 +18,29 @@ function startServer() {
     }
   });
 
+  let dbClosed = false;
+  const closeDatabase = () => {
+    if (dbClosed) return;
+    db.close((err) => {
+      if (err) {
+        console.error('Error closing database:', err.message);
+      } else {
+        console.log('Database connection closed.');
+      }
+    });
+    dbClosed = true;
+  };
+
+  process.on('SIGINT', () => {
+    closeDatabase();
+    process.exit(0);
+  });
+  process.on('SIGTERM', () => {
+    closeDatabase();
+    process.exit(0);
+  });
+  process.on('exit', closeDatabase);
+
   // Middleware setup
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
## Summary
- ensure SQLite connections in both Electron and Express processes are closed on application shutdown
- add process exit handlers and quit listeners for safe database cleanup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150e4f43c8328b450f0b9e9036ad5