### PR TITLE
feat: centralize configuration for port and database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Records Management System
+
+## Configuration
+
+This project reads runtime settings from environment variables via
+`config/settings.js`:
+
+- `PORT` – port number for the Express server (defaults to `49200`).
+- `DB_PATH` – path to the SQLite database file (defaults to
+  `./database/recordsmgmtsys.db`).
+
+The `npm start` script sets these defaults automatically, but they can be
+overridden when launching the application:
+
+```bash
+PORT=5000 DB_PATH=/path/to/recordsmgmtsys.db npm start
+```
+

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+// Application configuration values with sensible defaults
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 49200;
+const DB_PATH =
+  process.env.DB_PATH ||
+  path.resolve(__dirname, '../database/recordsmgmtsys.db');
+
+module.exports = { PORT, DB_PATH };

--- a/main.js
+++ b/main.js
@@ -8,13 +8,14 @@ const fs = require("fs");
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
+const { PORT, DB_PATH } = require('./config/settings');
 
 // Print userData path for debugging
 console.log('userData path:', app.getPath('userData'));
 
 // Determine the correct path for the database
-let dbPath;
-if (app.isPackaged) {
+let dbPath = DB_PATH;
+if (app.isPackaged && !process.env.DB_PATH) {
   // Production mode: Store the database in the userData folder
   dbPath = path.join(app.getPath('userData'), 'recordsmgmtsys.db');
 
@@ -37,9 +38,7 @@ if (app.isPackaged) {
     console.log('Database already exists in userData folder:', dbPath);
   }
 } else {
-  // Development mode: Use the local database path
-  dbPath = path.resolve(__dirname, './database/recordsmgmtsys.db');
-  console.log('Development mode DB Path:', dbPath); // Debugging the development path
+  console.log('Using database path:', dbPath);
 }
 
 // Initialize the database
@@ -53,7 +52,7 @@ const db = new sqlite3.Database(dbPath, (err) => {
 // Start Express server
 function startServer() {
   const app = express();
-  const PORT = process.env.PORT || 49200;
+  const port = PORT;
 
   // Middleware setup
   app.use(bodyParser.json());
@@ -448,8 +447,8 @@ app.post('/api/update-file', (req, res) => {
   });
 
   // Start the server and handle potential port conflict
-  const server = app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
+  const server = app.listen(port, () => {
+    console.log(`Server is running on port ${port}`);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Records Management System",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "PORT=${PORT:-49200} DB_PATH=${DB_PATH:-./database/recordsmgmtsys.db} electron .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "package": "electron-forge package",
     "make": "electron-forge make",

--- a/server.js
+++ b/server.js
@@ -1,15 +1,15 @@
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
-const path = require('path');
+const { PORT, DB_PATH } = require('./config/settings');
 
 // Start Express server
 function startServer() {
   const app = express();
-  const PORT = process.env.PORT || 49200;
+  const port = PORT;
 
   // Path to the SQLite database
-  const dbPath = path.resolve(__dirname, './database/recordsmgmtsys.db');
+  const dbPath = DB_PATH;
   const db = new sqlite3.Database(dbPath, (err) => {
     if (err) {
       console.error('Error connecting to the database:', err.message);
@@ -336,8 +336,8 @@ app.post('/api/update-letter', (req, res) => {
   });
 
   // Start the server and handle potential port conflict
-  const server = app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
+  const server = app.listen(port, () => {
+    console.log(`Server is running on port ${port}`);
   });
 }
 


### PR DESCRIPTION
## Summary
- add config/settings.js to read PORT and DB_PATH from environment
- use PORT and DB_PATH in main.js and server.js instead of literals
- document configuration and expose defaults via npm start script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150e834f48328b6b2ce569dd1a718