### PR TITLE
Add aria labels for icon buttons

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -76,7 +76,7 @@
           placeholder="Search for files or letters..."
           name="search"
         />
-        <button type="button">
+        <button type="button" aria-label="Search">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="16"
@@ -92,7 +92,7 @@
         </button>
       </div>
       <div class="nav2-functions icons">
-        <button type="button" class="" id="notification-icon">
+        <button type="button" class="" id="notification-icon" aria-label="Notifications">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"
@@ -106,7 +106,7 @@
             />
           </svg>
         </button>
-        <button type="button" class="" id="">
+        <button type="button" class="" id="" aria-label="Profile">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"
@@ -122,7 +122,7 @@
             />
           </svg>
         </button>
-        <button type="button" class="" id="">
+        <button type="button" class="" id="" aria-label="Settings">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"


### PR DESCRIPTION
## Summary
- add aria labels to search, notification, profile, and settings buttons

## Testing
- `npm test` *(fails: no test specified)*
- `node` axe-core check for button-name violations

------
https://chatgpt.com/codex/tasks/task_e_6891621bb71483288eb51ba2e3714262