### PR TITLE
Use decimal opacity values in dashboard styles

### DIFF
--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -98,7 +98,7 @@
       width: 100%;
       margin: 0 0 0 0;
       border-radius: 5px;
-      opacity: 20%;
+      opacity: 0.2;
     }
 
     .activity-sum {
@@ -118,11 +118,11 @@
       border: none;
       padding: 5px;
       font-size: 10pt;
-      opacity: 70%;
+      opacity: 0.7;
     }
 
     .activity-view-btn button:hover {
-      opacity: 90%;
+      opacity: 0.9;
       border: 2px solid #fff;
       transition: all 60ms ease-out;
     }


### PR DESCRIPTION
## Summary
- replace percent-based opacity values with decimal fractions in dashboard CSS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891631b58f483289d44910dd75546ad