### PR TITLE
Use brand token for dashboard dropdown hover state

### DIFF
--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -195,7 +195,7 @@
     /* Dropdown button on hover & focus */
     .dropbtn:hover,
     .dropbtn:focus {
-      background-color: #2980b9;
+      background-color: var(--primary-blue-500);
     }
 
     /* The container <div> - needed to position the dropdown content */
@@ -248,7 +248,7 @@
     /* Dropdown button on hover & focus */
     .dropbtn:hover,
     .dropbtn:focus {
-      background-color: #2980b9;
+      background-color: var(--primary-blue-500);
     }
 
     /* The container <div> - needed to position the dropdown content */


### PR DESCRIPTION
## Summary
- replace hard-coded #2980b9 with brand token `var(--primary-blue-500)` for `.dropbtn` hover state on dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68916327a5088328aa9cb12695adaecf