### PR TITLE
fix: table width respects container

### DIFF
--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -174,7 +174,7 @@
       padding: 2px;
       position: inherit;
       border-radius: 5px;
-      width: 100vh;
+      width: 100%;
       height: auto;
       color: rgb(20, 35, 50);
       /* border: 1px solid blue; */


### PR DESCRIPTION
## Summary
- make dashboard table width responsive to its container

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891632f0d5483289e796d4870420897