### PR TITLE
feat: add shadow design tokens

### DIFF
--- a/public/index/css/design-system.css
+++ b/public/index/css/design-system.css
@@ -1,0 +1,4 @@
+:root {
+  --shadow-md: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+}

--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -72,7 +72,7 @@
       border-radius: 5px;
       padding: 20px;
       color: white;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
+      box-shadow: var(--shadow-md);
     }
 
     .activity-title {
@@ -146,7 +146,7 @@
       width: 100%;
       padding: 20px;
       border-radius: 10px;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
+      box-shadow: var(--shadow-md);
     }
 
     .table-container {
@@ -211,7 +211,7 @@
       right: 6px;
       background-color: #f1f1f1;
       min-width: 160px;
-      box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+      box-shadow: var(--shadow-lg);
       z-index: 1;
     }
 
@@ -264,7 +264,7 @@
       right: 6px;
       background-color: #f1f1f1;
       min-width: 160px;
-      box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+      box-shadow: var(--shadow-lg);
       z-index: 1;
     }
 


### PR DESCRIPTION
## Summary
- define shared `--shadow-md` and `--shadow-lg` tokens in design system
- use shadow tokens across dashboard styles instead of hard-coded values

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68916333e45883289960b9c85521fb75