### PR TITLE
Include design system stylesheet on splash screen

### DIFF
--- a/src/splash-page/splash.html
+++ b/src/splash-page/splash.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="../../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <!-- Custom Fonts (Poppins) -->
     <link rel="stylesheet" href="../../public/index/css/font.css">
+    <link rel="stylesheet" href="../../public/index/css/design-system.css">
     <!-- Custom Stylesheet -->
     <link rel="stylesheet" href="./css/splash-styles.css">
 </head>


### PR DESCRIPTION
## Summary
- load shared design system CSS on the splash page ahead of custom styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891633e3eb88328b2b39e1861d080cf