### PR TITLE
Use decimal opacity values for splash page

### DIFF
--- a/src/splash-page/css/splash-styles.css
+++ b/src/splash-page/css/splash-styles.css
@@ -52,7 +52,7 @@ body {
 
 .splashContent-title h1 {
   color: rgba(255, 255, 255, 0.1);
-  opacity: 40%;
+  opacity: 0.4;
   font-size: 8vw;
   font-weight: 100;
   margin: 0;
@@ -118,13 +118,13 @@ body {
   position: relative;
   top: -3px;
   right: -15px;
-  opacity: 70%;
+  opacity: 0.7;
 }
 
 .splashContent-end p:nth-last-child(1) {
   font-size: 1rem;
   font-weight: 400;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .divider {
@@ -136,7 +136,7 @@ body {
   height: 8vh;
   width: 2px;
   background-color: rgba(255, 255, 255, 1);
-  opacity: 40%;
+  opacity: 0.4;
   z-index: 100;
 }
 


### PR DESCRIPTION
## Summary
- switch splash page opacity values from percentages to decimals

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891634e4a9c83288cef03831161a0f9