### PR TITLE
Use Bootstrap styles for splash login button

### DIFF
--- a/src/splash-page/css/splash-styles.css
+++ b/src/splash-page/css/splash-styles.css
@@ -280,25 +280,6 @@ input.error {
   width: 510px;
 }
 
-.modalContent-end button {
-  height: 60px;
-  width: 133px;
-  font-size: 16pt;
-  font-weight: 600;
-  color: white;
-  background-color: #142332;
-  border-radius: 5px;
-  border: none;
-}
-
-.modalContent-end button:hover {
-  background-color: rgba(20, 35, 50, 0.95);
-}
-
-.modalContent-end button:active {
-  border: 3px solid rgba(20, 35, 50, 0.5);
-}
-
 .modalContent-end a {
   text-decoration: none;
   color: rgba(20, 35, 50, 0.5);

--- a/src/splash-page/splash.html
+++ b/src/splash-page/splash.html
@@ -52,7 +52,7 @@
                             <input type="password" placeholder="Password" name="password" required>
                         </div>
                         <div class="modalContent-end">
-                            <button id="login-btn">Log In</button>
+                            <button id="login-btn" class="btn btn-primary">Log In</button>
                             <a href="#">Forgot password?</a>
                         </div>
                     </form>


### PR DESCRIPTION
## Summary
- Use Bootstrap `btn btn-primary` classes for splash login button
- Remove custom modal login button styles

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891635375588328b55b4a402418e6be