### PR TITLE
Add centralized Express error handling

### DIFF
--- a/src/server/errorHandler.js
+++ b/src/server/errorHandler.js
@@ -1,0 +1,4 @@
+module.exports = function errorHandler(err, req, res, next) {
+  console.error(err);
+  res.status(500).json({ error: err.message });
+};


### PR DESCRIPTION
## Summary
- add `src/server/errorHandler.js` middleware to log errors and return JSON responses
- wire `errorHandler` into Express apps and forward route errors with `next`
- remove per-route `console.error`/`res.status(500)` blocks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150e4c8cc83288f7d0a500a236454