### PR TITLE
Add focus ring styling for interactive elements

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -69,19 +69,20 @@
       <div class="nav2-title">
         <span class="h5">Files Office (LVD)</span>
       </div>
-      <div class="searchbar">
-        <input
-          type="text"
-          id="system-search"
-          placeholder="Search for files or letters..."
-          name="search"
-        />
-        <button type="button">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            fill="currentColor"
+        <div class="searchbar">
+          <input
+            type="text"
+            id="system-search"
+            placeholder="Search for files or letters..."
+            name="search"
+            class="focus-ring"
+          />
+          <button type="button" class="focus-ring">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
             class="bi bi-search"
             viewBox="0 0 16 16"
           >
@@ -91,30 +92,30 @@
           </svg>
         </button>
       </div>
-      <div class="nav2-functions icons">
-        <button type="button" class="" id="notification-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            fill="currentColor"
-            class="bi bi-bell"
-            viewBox="0 0 16 16"
-          >
-            <path
+        <div class="nav2-functions icons">
+          <button type="button" class="focus-ring" id="notification-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              fill="currentColor"
+              class="bi bi-bell"
+              viewBox="0 0 16 16"
+            >
+              <path
               d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2M8 1.918l-.797.161A4 4 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4 4 0 0 0-3.203-3.92zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5 5 0 0 1 13 6c0 .88.32 4.2 1.22 6"
             />
           </svg>
         </button>
-        <button type="button" class="" id="">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            fill="currentColor"
-            class="bi bi-person-circle"
-            viewBox="0 0 16 16"
-          >
+          <button type="button" class="focus-ring" id="">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              fill="currentColor"
+              class="bi bi-person-circle"
+              viewBox="0 0 16 16"
+            >
             <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0" />
             <path
               fill-rule="evenodd"
@@ -122,15 +123,15 @@
             />
           </svg>
         </button>
-        <button type="button" class="" id="">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            fill="currentColor"
-            class="bi bi-gear"
-            viewBox="0 0 16 16"
-          >
+          <button type="button" class="focus-ring" id="">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              fill="currentColor"
+              class="bi bi-gear"
+              viewBox="0 0 16 16"
+            >
             <path
               d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492M5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0"
             />
@@ -192,7 +193,7 @@
             <li>
               <div
                 id="menu-dashboard"
-                class="dashboard-link menu-list"
+                class="dashboard-link menu-list focus-ring"
                 data-content-url="dashboard"
               >
                 Dashboard
@@ -202,7 +203,7 @@
             <!-- List Item For File Management -->
             <li>
               <div
-                class="fileMgmt-link menu-list"
+                class="fileMgmt-link menu-list focus-ring"
                 id="menu-files"
                 data-content-url="file-management"
               >
@@ -213,7 +214,7 @@
             <!-- List Item For Letter Management -->
             <li>
               <div
-                class="letterMgmt-link menu-list"
+                class="letterMgmt-link menu-list focus-ring"
                 id="menu-letters"
                 data-content-url="letter-management"
               >
@@ -225,7 +226,7 @@
             <li>
               <div
                 id="menu-reports"
-                class="reports-link menu-list"
+                class="reports-link menu-list focus-ring"
                 data-content-url="reports"
               >
                 Report Management
@@ -236,7 +237,7 @@
             <li>
               <div
                 id="menu-users"
-                class="users-link menu-list"
+                class="users-link menu-list focus-ring"
                 data-content-url="users"
               >
                 User Management
@@ -252,11 +253,11 @@
             <li>Account</li>
             <li>Help & Support</li>
             <li>
-              <button
-                type="button"
-                class="sidebar-sign-out"
-                id="sign-out-button"
-              >
+                <button
+                  type="button"
+                  class="sidebar-sign-out focus-ring"
+                  id="sign-out-button"
+                >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="20"

--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -316,3 +316,14 @@
       background-color: #d1ecf1;
       /* Light blue for IN */
     }
+
+    /* Focus ring for accessibility */
+    .focus-ring {
+      outline: 2px solid var(--primary-blue-500);
+      outline-offset: 2px;
+    }
+
+    .focus-ring:focus {
+      outline: 2px solid var(--primary-blue-500);
+      outline-offset: 2px;
+    }

--- a/src/splash-page/css/splash-styles.css
+++ b/src/splash-page/css/splash-styles.css
@@ -316,3 +316,14 @@ input.error {
 #error-msg {
   font-size: 0.9em;
 }
+
+/* Focus ring for accessibility */
+.focus-ring {
+  outline: 2px solid var(--primary-blue-500);
+  outline-offset: 2px;
+}
+
+.focus-ring:focus {
+  outline: 2px solid var(--primary-blue-500);
+  outline-offset: 2px;
+}

--- a/src/splash-page/splash.html
+++ b/src/splash-page/splash.html
@@ -48,11 +48,11 @@
                 <div class="modalForm">
                     <form class="modalContent">
                         <div class="modalContent-main">
-                            <input type="text" placeholder="Username" name="username" required>
-                            <input type="password" placeholder="Password" name="password" required>
+                            <input type="text" placeholder="Username" name="username" required class="focus-ring">
+                            <input type="password" placeholder="Password" name="password" required class="focus-ring">
                         </div>
                         <div class="modalContent-end">
-                            <button id="login-btn">Log In</button>
+                            <button id="login-btn" class="focus-ring">Log In</button>
                             <a href="#">Forgot password?</a>
                         </div>
                     </form>

--- a/views/pages/dashboard.ejs
+++ b/views/pages/dashboard.ejs
@@ -2,7 +2,7 @@
     <div class="dashboard-title" id="menu-list-title">
         <div class="h1 title">Dashboard | Overview</div>
         <div class="refresh-dashboard">
-            <button class="dashboard-reload" id="refresh-btn">
+            <button class="dashboard-reload focus-ring" id="refresh-btn">
               <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-arrow-repeat" viewBox="0 0 16 16">
                 <path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41m-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9" />
                 <path fill-rule="evenodd" d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5 5 0 0 0 8 3M3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9z" />
@@ -35,7 +35,7 @@
                 <div class="entries-sum activity-sum">
                     <div class="entries-int activity-int" id="entries-count">0</div>
                     <div class="entries-view-btn activity-view-btn">
-                        <button type="button" class="view-btn" data-content-url="entries">View</button>
+                        <button type="button" class="view-btn focus-ring" data-content-url="entries">View</button>
                     </div>
                 </div>
             </div>
@@ -60,7 +60,7 @@
                 <div class="entries-sum activity-sum">
                     <div class="entries-int activity-int" id="letters-count">0</div>
                     <div class="entries-view-btn activity-view-btn">
-                        <button type="button" class="view-btn" data-content-url="letter-management">View</button>
+                        <button type="button" class="view-btn focus-ring" data-content-url="letter-management">View</button>
                     </div>
                 </div>
             </div>
@@ -85,7 +85,7 @@
                 <div class="entries-sum activity-sum">
                     <div class="entries-int activity-int" id="files-count">0</div>
                     <div class="entries-view-btn activity-view-btn">
-                        <button type="button" class="view-btn" data-content-url="file-management">View</button>
+                        <button type="button" class="view-btn focus-ring" data-content-url="file-management">View</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add reusable `.focus-ring` styles for dashboard and splash pages
- apply `focus-ring` classes to dashboard search controls, nav buttons, sidebar links, and sign-out button
- mark up splash login form and dashboard controls with `focus-ring` for accessible focus states

## Testing
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_68916357ee888328bbfd5cfa84c7935a