### PR TITLE
style: use gray color variables for menu list

### DIFF
--- a/public/index/css/styles.css
+++ b/public/index/css/styles.css
@@ -188,8 +188,8 @@ aside li {
   font-weight: bold;
   cursor: pointer;
   padding: 10px;
-  border: 1px solid #ccc;
-  background-color: #f8f9fa;
+  border: 1px solid var(--gray-300);
+  background-color: var(--gray-50);
   border-radius: 5px;
   transition: background-color 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- replace hard-coded menu-list colors with `var(--gray-300)` and `var(--gray-50)`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891635f32588328b9e0e62d5ce43703