### PR TITLE
feat: add theme toggle

### DIFF
--- a/public/index/css/styles.css
+++ b/public/index/css/styles.css
@@ -8,6 +8,11 @@ body {
   height: 100vh;
 }
 
+[data-theme="dark"] body {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+
 /* Second Navbar */
 nav {
   border-bottom: 1px solid rgba(20, 35, 50, 0.1);

--- a/public/index/js/renderer.js
+++ b/public/index/js/renderer.js
@@ -12,6 +12,26 @@ document.addEventListener("DOMContentLoaded", function () {
   // Get the element with the class 'dashboard-link'
   const dashboardLink = document.querySelector(".dashboard-link");
 
+  // Theme toggle setup
+  const themeToggle = document.getElementById("theme-toggle");
+  const root = document.documentElement;
+  const savedTheme = localStorage.getItem("theme");
+  if (savedTheme === "dark") {
+    root.setAttribute("data-theme", "dark");
+    if (themeToggle) {
+      themeToggle.checked = true;
+    }
+  }
+  themeToggle?.addEventListener("change", () => {
+    if (themeToggle.checked) {
+      root.setAttribute("data-theme", "dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      root.removeAttribute("data-theme");
+      localStorage.setItem("theme", "light");
+    }
+  });
+
   // Add the 'active' class to it on load
   if (dashboardLink) {
     dashboardLink.classList.add("active");

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -92,6 +92,9 @@
         </button>
       </div>
       <div class="nav2-functions icons">
+        <div class="form-check form-switch m-0">
+          <input class="form-check-input" type="checkbox" id="theme-toggle" />
+        </div>
         <button type="button" class="" id="notification-icon">
           <svg
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- add theme toggle switch to navbar
- implement data-theme toggle with persistence in localStorage
- add basic dark theme styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68916250e5d8832880087bd406e30d6e