### PR TITLE
style: neutral dashboard activity border token

### DIFF
--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -141,7 +141,7 @@
 
     /* Activity Container 2 */
     .activity2 {
-      border: 1px solid pink;
+      border: 1px solid var(--gray-200);
       height: fit-content;
       width: 100%;
       padding: 20px;


### PR DESCRIPTION
## Summary
- use gray design token for dashboard activity card border

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689162353db08328ba5078e3841b595e