### PR TITLE
refactor: use spacing tokens in dashboard styles

### DIFF
--- a/src/partials-public/dashboard/css/dashboard-styles.css
+++ b/src/partials-public/dashboard/css/dashboard-styles.css
@@ -26,7 +26,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 20px 0;
+      padding: var(--space-5) 0;
       height: fit-content;
       width: 100%;
     }
@@ -70,7 +70,7 @@
       height: 250px;
       width: 100%;
       border-radius: 5px;
-      padding: 20px;
+      padding: var(--space-5);
       color: white;
       box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
     }
@@ -131,12 +131,12 @@
 
     /* LETTERS */
     #total-letters {
-      margin: 0 0 0 40px;
+      margin: 0 0 0 var(--space-10);
     }
 
     /* FILES */
     #total-files {
-      margin: 0 0 0 40px;
+      margin: 0 0 0 var(--space-10);
     }
 
     /* Activity Container 2 */
@@ -144,7 +144,7 @@
       border: 1px solid pink;
       height: fit-content;
       width: 100%;
-      padding: 20px;
+      padding: var(--space-5);
       border-radius: 10px;
       box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
     }
@@ -218,7 +218,7 @@
     /* Links inside the dropdown */
     .dropdown-content a {
       color: black;
-      padding: 12px 16px;
+      padding: var(--space-3) var(--space-4);
       text-decoration: none;
       display: block;
     }
@@ -271,7 +271,7 @@
     /* Links inside the dropdown */
     .dropdown-content a {
       color: black;
-      padding: 12px 16px;
+      padding: var(--space-3) var(--space-4);
       text-decoration: none;
       display: block;
     }


### PR DESCRIPTION
## Summary
- replace hard-coded padding with spacing tokens
- convert 40px margins to design system tokens
- use spacing tokens in dropdown link padding

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68916227a3f083288d16d3ffc5be3891