### PR TITLE
refactor: use design tokens for menu list styles

### DIFF
--- a/public/index/css/styles.css
+++ b/public/index/css/styles.css
@@ -188,20 +188,22 @@ aside li {
   font-weight: bold;
   cursor: pointer;
   padding: 10px;
-  border: 1px solid #ccc;
-  background-color: #f8f9fa;
+  border: 1px solid var(--gray-300);
+  background-color: var(--gray-50);
   border-radius: 5px;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
-.active {
-  color: white;
-  background-color: rgb(20, 30, 52);
+.menu-list:hover,
+.menu-list:active {
+  background-color: var(--gray-100);
+  border-color: var(--gray-400);
 }
 
+.active,
 .focus {
-  color: white;
-  background-color: rgb(20, 30, 52);
+  color: var(--white);
+  background-color: var(--primary-blue-500);
 }
 
 .submenu {


### PR DESCRIPTION
## Summary
- replace hard-coded menu list colors with design tokens
- apply token-based colors for hover and active states
- update active/focus menu styles to use primary brand token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689162036370832891805c623949f706