### PR TITLE
Fix nav layout alignment

### DIFF
--- a/public/index/css/styles.css
+++ b/public/index/css/styles.css
@@ -61,7 +61,7 @@ div.searchbar button:hover {
 nav div.nav2-functions {
   display: flex;
   align-items: center;
-  justify: center;
+  justify-content: center;
 }
 
 nav div.nav2-functions button {


### PR DESCRIPTION
## Summary
- use `justify-content: center` to properly center nav2 function icons

## Testing
- `node - <<'NODE'...` (puppeteer) shows computed style `justify-content: center`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689162096a708328ae24c850a85bcec3