### PR TITLE
feat: add database initialization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Records Management System
+
+## Database Initialization
+
+The application uses a SQLite database located at `database/recordsmgmtsys.db`.
+Run the following command to create the required tables:
+
+```bash
+npm run init-db
+```
+
+## Schema Migrations
+
+When the database schema changes:
+
+1. Create a new SQL migration file in a separate directory (e.g., `config/migrations`).
+2. Run the migration against the existing database using the `sqlite3` CLI or a Node script.
+3. Update `config/init-database.js` so fresh installations include the new schema.
+4. Commit both the migration file and any related code changes.

--- a/config/init-database.js
+++ b/config/init-database.js
@@ -1,0 +1,55 @@
+const sqlite3 = require('sqlite3').verbose();
+const fs = require('fs');
+const path = require('path');
+
+// Ensure the database directory exists
+const dbDir = path.resolve(__dirname, '../database');
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
+const dbPath = path.join(dbDir, 'recordsmgmtsys.db');
+const db = new sqlite3.Database(dbPath);
+
+// Create required tables
+// users_tbl stores application users
+// entries_tbl stores both letter and file entries
+
+db.serialize(() => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS users_tbl (
+      user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      password TEXT NOT NULL,
+      user_role TEXT NOT NULL
+    );
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS entries_tbl (
+      entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      entry_date TEXT NOT NULL,
+      entry_category TEXT NOT NULL,
+      file_number TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      officer_assigned TEXT NOT NULL,
+      recieved_date TEXT,
+      date_sent TEXT,
+      file_type TEXT,
+      reciepient TEXT,
+      description TEXT,
+      status TEXT NOT NULL,
+      letter_date TEXT,
+      letter_type TEXT,
+      folio_number TEXT
+    );
+  `);
+});
+
+db.close((err) => {
+  if (err) {
+    console.error('Error closing database:', err.message);
+  } else {
+    console.log('Database initialized at', dbPath);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "build": "webpack",
-    "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json"
+    "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json",
+    "init-db": "node config/init-database.js"
   },
   "keywords": [
     "records",
@@ -59,20 +60,20 @@
     "electron-rebuild": "^3.2.9",
     "webpack-bundle-analyzer": "^4.10.2"
   },
-"build": {
-  "appId": "com.codecol.recordsmanagement",
-  "productName": "Records Management System",
-  "directories": {
-    "output": "dist"
-  },
-  "files": [
-    "dist/**/*",
-    "node_modules/**/*",
-    "main.js",
-    "index.html",
-    "package.json",
-    "database/**/*"
-  ],
+  "build": {
+    "appId": "com.codecol.recordsmanagement",
+    "productName": "Records Management System",
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "dist/**/*",
+      "node_modules/**/*",
+      "main.js",
+      "index.html",
+      "package.json",
+      "database/**/*"
+    ],
     "publish": [
       {
         "provider": "github",


### PR DESCRIPTION
## Summary
- add script to create required SQLite tables
- expose `npm run init-db` for database setup
- document database setup and migration workflow

## Testing
- `npm run init-db`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150e28b4c8328b69079987ad263a7