### PR TITLE
feat: add file upload support and cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.8.2",
     "latest": "^0.2.0",
+    "multer": "^1.4.5-lts.1",
     "print-this": "^2.0.0",
     "puppeteer": "^23.3.0",
     "sql.js": "^1.11.0",
@@ -59,20 +60,20 @@
     "electron-rebuild": "^3.2.9",
     "webpack-bundle-analyzer": "^4.10.2"
   },
-"build": {
-  "appId": "com.codecol.recordsmanagement",
-  "productName": "Records Management System",
-  "directories": {
-    "output": "dist"
-  },
-  "files": [
-    "dist/**/*",
-    "node_modules/**/*",
-    "main.js",
-    "index.html",
-    "package.json",
-    "database/**/*"
-  ],
+  "build": {
+    "appId": "com.codecol.recordsmanagement",
+    "productName": "Records Management System",
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "dist/**/*",
+      "node_modules/**/*",
+      "main.js",
+      "index.html",
+      "package.json",
+      "database/**/*"
+    ],
     "publish": [
       {
         "provider": "github",

--- a/views/pages/file-management.ejs
+++ b/views/pages/file-management.ejs
@@ -38,7 +38,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <form id="fileForm">
+                <form id="fileForm" enctype="multipart/form-data">
                     <div class="container">
                         <div class="row mb-3">
                             <!-- Entry Date -->
@@ -132,6 +132,11 @@
                                     <option value="OUT">OUT</option>
                                     <option value="IN">IN</option>
                                 </select>
+                            </div>
+                            <!-- Attachment -->
+                            <div class="col-md-6">
+                                <label for="attachment" class="form-label">Attachment</label>
+                                <input type="file" class="form-control" id="attachment" name="attachment">
                             </div>
                         </div>
                         <!-- Hidden Field for Entry ID -->


### PR DESCRIPTION
## Summary
- configure Multer for 10MB uploads with type filtering and /uploads route
- allow adding and updating files with attachments stored in `entries_tbl.file_path`
- serve and remove uploaded files when entries are accessed or deleted

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68915e467ce083288b03d83feae2cd4d