### PR TITLE
feat: add audit history tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "build": "webpack",

--- a/server.js
+++ b/server.js
@@ -8,8 +8,10 @@ function startServer() {
   const app = express();
   const PORT = process.env.PORT || 49200;
 
-  // Path to the SQLite database
-  const dbPath = path.resolve(__dirname, './database/recordsmgmtsys.db');
+  // Path to the SQLite database (allow override for tests)
+  const resolvedPath =
+    process.env.DB_PATH === ':memory:' ? ':memory:' : (process.env.DB_PATH || './database/recordsmgmtsys.db');
+  const dbPath = resolvedPath === ':memory:' ? resolvedPath : path.resolve(__dirname, resolvedPath);
   const db = new sqlite3.Database(dbPath, (err) => {
     if (err) {
       console.error('Error connecting to the database:', err.message);
@@ -17,6 +19,16 @@ function startServer() {
       console.log('Connected to the SQLite database.');
     }
   });
+
+  // Ensure history table exists
+  db.run(`CREATE TABLE IF NOT EXISTS history_tbl (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_id INTEGER,
+    user_id INTEGER,
+    action TEXT NOT NULL,
+    changes TEXT,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+  );`);
 
   // Middleware setup
   app.use(bodyParser.json());
@@ -114,59 +126,126 @@ app.get('/api/get-files', (req, res) => {
 });
 
 // ADD FILE TO TABLE
-app.post('/api/add-file', (req, res) => {
-  const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
+  app.post('/api/add-file', (req, res) => {
+    const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description, user_id } = req.body;
 
-  // Check only for required fields
-  if (!entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
-    return res.status(400).json({ error: 'Missing required fields' });
-  }
-
-  // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;
-  const recievedDateValue = recieved_date || null;
-  const descriptionValue = description || null;
-
-  const query = `
-    INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, reciepient, description, status)
-    VALUES (?, 'File', ?, ?, ?, ?, ?, ?, ?, ?, ?);
-  `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, reciepientValue, descriptionValue, status], function (err) {
-    if (err) {
-      console.error("Error inserting new file:", err.message);
-      return res.status(500).json({ error: err.message });
+    if (!entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
+      return res.status(400).json({ error: 'Missing required fields' });
     }
-    res.status(201).json({ message: 'File added successfully', entry_id: this.lastID });
+
+    const reciepientValue = reciepient || null;
+    const recievedDateValue = recieved_date || null;
+    const descriptionValue = description || null;
+
+    const query = `
+      INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, reciepient, description, status)
+      VALUES (?, 'File', ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    `;
+
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      db.run(query, [entry_date, file_number, subject, officer_assigned, recievedDateValue, date_sent, file_type, reciepientValue, descriptionValue, status], function (err) {
+        if (err) {
+          return db.run('ROLLBACK', () => {
+            console.error("Error inserting new file:", err.message);
+            res.status(500).json({ error: err.message });
+          });
+        }
+
+        const entryId = this.lastID;
+        const changes = {
+          entry_date,
+          file_number,
+          subject,
+          officer_assigned,
+          status,
+          recieved_date: recievedDateValue,
+          date_sent,
+          file_type,
+          reciepient: reciepientValue,
+          description: descriptionValue
+        };
+
+        db.run(
+          `INSERT INTO history_tbl (entry_id, user_id, action, changes) VALUES (?, ?, ?, ?)`,
+          [entryId, user_id || null, 'CREATE', JSON.stringify(changes)],
+          (err2) => {
+            if (err2) {
+              return db.run('ROLLBACK', () => res.status(500).json({ error: err2.message }));
+            }
+            db.run('COMMIT', (commitErr) => {
+              if (commitErr) {
+                return db.run('ROLLBACK', () => res.status(500).json({ error: commitErr.message }));
+              }
+              res.status(201).json({ message: 'File added successfully', entry_id: entryId });
+            });
+          }
+        );
+      });
+    });
   });
-});
 
 // UPDATE FILE IN TABLE
-app.post('/api/update-file', (req, res) => {
-  const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, reciepient, file_type, folio_number, description } = req.body;
+  app.post('/api/update-file', (req, res) => {
+    const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, reciepient, file_type, folio_number, description, user_id } = req.body;
 
-  // Check only for required fields
-  if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
-    return res.status(400).json({ error: 'Missing required fields' });
-  }
-
-  // Use null for optional fields if not provided
-  const reciepientValue = reciepient || null;
-  const recievedDateValue = folio_number || null;
-  const descriptionValue = description || null;
-
-  const query = `
-    UPDATE entries_tbl
-    SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, date_sent = ?, reciepient = ?, file_type = ?, folio_number = ?, description = ?, status = ?
-    WHERE entry_id = ? AND entry_category = 'File';
-  `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, date_sent, file_type, recievedDateValue,reciepientValue, descriptionValue, status, entry_id], function (err) {
-    if (err) {
-      console.error("Error updating file:", err.message);
-      return res.status(500).json({ error: err.message });
+    if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !date_sent || !file_type) {
+      return res.status(400).json({ error: 'Missing required fields' });
     }
-    res.status(200).json({ message: 'File updated successfully' });
+
+    const reciepientValue = reciepient || null;
+    const folioNumberValue = folio_number || null;
+    const descriptionValue = description || null;
+
+    const query = `
+      UPDATE entries_tbl
+      SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, date_sent = ?, reciepient = ?, file_type = ?, folio_number = ?, description = ?, status = ?
+      WHERE entry_id = ? AND entry_category = 'File';
+    `;
+
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, date_sent, reciepientValue, file_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
+        if (err) {
+          return db.run('ROLLBACK', () => {
+            console.error("Error updating file:", err.message);
+            res.status(500).json({ error: err.message });
+          });
+        }
+
+        const changes = {
+          entry_id,
+          entry_date,
+          file_number,
+          subject,
+          officer_assigned,
+          status,
+          recieved_date,
+          date_sent,
+          reciepient: reciepientValue,
+          file_type,
+          folio_number: folioNumberValue,
+          description: descriptionValue
+        };
+
+        db.run(
+          `INSERT INTO history_tbl (entry_id, user_id, action, changes) VALUES (?, ?, ?, ?)`,
+          [entry_id, user_id || null, 'UPDATE', JSON.stringify(changes)],
+          (err2) => {
+            if (err2) {
+              return db.run('ROLLBACK', () => res.status(500).json({ error: err2.message }));
+            }
+            db.run('COMMIT', (commitErr) => {
+              if (commitErr) {
+                return db.run('ROLLBACK', () => res.status(500).json({ error: commitErr.message }));
+              }
+              res.status(200).json({ message: 'File updated successfully' });
+            });
+          }
+        );
+      });
+    });
   });
-});
 
   // LETTER MANAGEMENT SECTION
   // GET LETTERS FROM TABLE
@@ -186,73 +265,164 @@ app.post('/api/update-file', (req, res) => {
   });
 
 // ADD LETTER TO TABLE
-app.post('/api/add-letter', (req, res) => {
-  const { entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
+  app.post('/api/add-letter', (req, res) => {
+    const { entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description, user_id } = req.body;
 
-  // Check only for required fields
-  if (!entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
-      return res.status(400).json({ error: 'Missing required fields' });
-  }
+    if (!entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
+        return res.status(400).json({ error: 'Missing required fields' });
+    }
 
-  // Use null for optional fields if not provided
-  const folioNumberValue = folio_number || null;
-  const descriptionValue = description || null;
+    const folioNumberValue = folio_number || null;
+    const descriptionValue = description || null;
 
-  const query = `
-      INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folio_number, description, status)
-      VALUES (?, 'Letter', ?, ?, ?, ?, ?, ?, ?, ?, ?);
-  `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status], function (err) {
-      if (err) {
-          console.error("Error inserting new letter:", err.message);
-          return res.status(500).json({ error: err.message });
-      }
-      res.status(201).json({ message: 'Letter added successfully', entry_id: this.lastID });
+    const query = `
+        INSERT INTO entries_tbl (entry_date, entry_category, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folio_number, description, status)
+        VALUES (?, 'Letter', ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    `;
+
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status], function (err) {
+        if (err) {
+          return db.run('ROLLBACK', () => {
+            console.error("Error inserting new letter:", err.message);
+            res.status(500).json({ error: err.message });
+          });
+        }
+
+        const entryId = this.lastID;
+        const changes = {
+          entry_date,
+          file_number,
+          subject,
+          officer_assigned,
+          status,
+          recieved_date,
+          letter_date,
+          letter_type,
+          folio_number: folioNumberValue,
+          description: descriptionValue
+        };
+
+        db.run(
+          `INSERT INTO history_tbl (entry_id, user_id, action, changes) VALUES (?, ?, ?, ?)`,
+          [entryId, user_id || null, 'CREATE', JSON.stringify(changes)],
+          (err2) => {
+            if (err2) {
+              return db.run('ROLLBACK', () => res.status(500).json({ error: err2.message }));
+            }
+            db.run('COMMIT', (commitErr) => {
+              if (commitErr) {
+                return db.run('ROLLBACK', () => res.status(500).json({ error: commitErr.message }));
+              }
+              res.status(201).json({ message: 'Letter added successfully', entry_id: entryId });
+            });
+          }
+        );
+      });
+    });
   });
-});
 
 
   // UPDATE LETTER IN TABLE
-app.post('/api/update-letter', (req, res) => {
-  const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
+  app.post('/api/update-letter', (req, res) => {
+    const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description, user_id } = req.body;
 
-  // Check only for required fields
-  if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
-      return res.status(400).json({ error: 'Missing required fields' });
-  }
+    if (!entry_id || !entry_date || !file_number || !subject || !officer_assigned || !status || !recieved_date || !letter_date || !letter_type) {
+        return res.status(400).json({ error: 'Missing required fields' });
+    }
 
-  // Use null for optional fields if not provided
-  const folioNumberValue = folio_number || null;
-  const descriptionValue = description || null;
+    const folioNumberValue = folio_number || null;
+    const descriptionValue = description || null;
 
-  const query = `
-      UPDATE entries_tbl
-      SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, letter_date = ?, letter_type = ?, folio_number = ?, description = ?, status = ?
-      WHERE entry_id = ? AND entry_category = 'Letter';
-  `;
-  db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
-      if (err) {
-          console.error("Error updating letter:", err.message);
-          return res.status(500).json({ error: err.message });
-      }
-      res.status(200).json({ message: 'Letter updated successfully' });
+    const query = `
+        UPDATE entries_tbl
+        SET entry_date = ?, file_number = ?, subject = ?, officer_assigned = ?, recieved_date = ?, letter_date = ?, letter_type = ?, folio_number = ?, description = ?, status = ?
+        WHERE entry_id = ? AND entry_category = 'Letter';
+    `;
+
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      db.run(query, [entry_date, file_number, subject, officer_assigned, recieved_date, letter_date, letter_type, folioNumberValue, descriptionValue, status, entry_id], function (err) {
+        if (err) {
+          return db.run('ROLLBACK', () => {
+            console.error("Error updating letter:", err.message);
+            res.status(500).json({ error: err.message });
+          });
+        }
+
+        const changes = {
+          entry_id,
+          entry_date,
+          file_number,
+          subject,
+          officer_assigned,
+          status,
+          recieved_date,
+          letter_date,
+          letter_type,
+          folio_number: folioNumberValue,
+          description: descriptionValue
+        };
+
+        db.run(
+          `INSERT INTO history_tbl (entry_id, user_id, action, changes) VALUES (?, ?, ?, ?)`,
+          [entry_id, user_id || null, 'UPDATE', JSON.stringify(changes)],
+          (err2) => {
+            if (err2) {
+              return db.run('ROLLBACK', () => res.status(500).json({ error: err2.message }));
+            }
+            db.run('COMMIT', (commitErr) => {
+              if (commitErr) {
+                return db.run('ROLLBACK', () => res.status(500).json({ error: commitErr.message }));
+              }
+              res.status(200).json({ message: 'Letter updated successfully' });
+            });
+          }
+        );
+      });
+    });
   });
-});
 
 
   // DELETE ENTRY IN TABLE
   app.delete('/api/delete-entry/:entry_id', (req, res) => {
     const entryId = req.params.entry_id;
-    const query = `
-          DELETE FROM entries_tbl
-          WHERE entry_id = ?;
-      `;
-    db.run(query, [entryId], function (err) {
-      if (err) {
-        console.error("Error deleting Entry:", err.message);
-        return res.status(500).json({ error: err.message });
-      }
-      res.status(200).json({ message: 'Entry deleted successfully' });
+    const { user_id } = req.body;
+    const deleteQuery = `DELETE FROM entries_tbl WHERE entry_id = ?;`;
+
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      db.get('SELECT * FROM entries_tbl WHERE entry_id = ?', [entryId], (selectErr, row) => {
+        if (selectErr) {
+          return db.run('ROLLBACK', () => res.status(500).json({ error: selectErr.message }));
+        }
+
+        db.run(deleteQuery, [entryId], function (err) {
+          if (err) {
+            return db.run('ROLLBACK', () => {
+              console.error("Error deleting Entry:", err.message);
+              res.status(500).json({ error: err.message });
+            });
+          }
+
+          db.run(
+            `INSERT INTO history_tbl (entry_id, user_id, action, changes) VALUES (?, ?, ?, ?)`,
+            [entryId, user_id || null, 'DELETE', JSON.stringify(row || {})],
+            (err2) => {
+              if (err2) {
+                return db.run('ROLLBACK', () => res.status(500).json({ error: err2.message }));
+              }
+              db.run('COMMIT', (commitErr) => {
+                if (commitErr) {
+                  return db.run('ROLLBACK', () => res.status(500).json({ error: commitErr.message }));
+                }
+                res.status(200).json({ message: 'Entry deleted successfully' });
+              });
+            }
+          );
+        });
+      });
     });
   });
 
@@ -311,10 +481,44 @@ app.post('/api/update-letter', (req, res) => {
     });
   });
 
+  // History retrieval with pagination and filters
+  app.get('/api/history', (req, res) => {
+    const { page = 1, limit = 10, entry_id, user_id, start_date, end_date } = req.query;
+    let query = `SELECT * FROM history_tbl WHERE 1=1`;
+    const params = [];
+
+    if (entry_id) {
+      query += ' AND entry_id = ?';
+      params.push(entry_id);
+    }
+    if (user_id) {
+      query += ' AND user_id = ?';
+      params.push(user_id);
+    }
+    if (start_date) {
+      query += ' AND timestamp >= ?';
+      params.push(start_date);
+    }
+    if (end_date) {
+      query += ' AND timestamp <= ?';
+      params.push(end_date);
+    }
+
+    query += ' ORDER BY timestamp DESC LIMIT ? OFFSET ?';
+    params.push(parseInt(limit), (parseInt(page) - 1) * parseInt(limit));
+
+    db.all(query, params, (err, rows) => {
+      if (err) {
+        return res.status(500).json({ error: err.message });
+      }
+      res.json({ data: rows });
+    });
+  });
+
 
   // Server route modifications
   app.post('/api/update-entry', (req, res) => {
-    const { entry_id, file_number, status } = req.body;
+    const { entry_id, file_number, status, user_id } = req.body;
     if (!entry_id || !file_number || !status) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
@@ -324,14 +528,34 @@ app.post('/api/update-letter', (req, res) => {
         SET file_number = ?, status = ?
         WHERE entry_id = ?;
     `;
-    db.run(query, [file_number, status, entry_id], function (err) {
-      if (err) {
-        return res.status(500).json({ error: err.message });
-      }
-      if (this.changes === 0) {
-        return res.status(404).json({ error: 'Entry not found' });
-      }
-      res.json({ message: 'Entry updated successfully' });
+
+    db.serialize(() => {
+      db.run('BEGIN TRANSACTION');
+      db.run(query, [file_number, status, entry_id], function (err) {
+        if (err) {
+          return db.run('ROLLBACK', () => res.status(500).json({ error: err.message }));
+        }
+        if (this.changes === 0) {
+          return db.run('ROLLBACK', () => res.status(404).json({ error: 'Entry not found' }));
+        }
+
+        const changes = { file_number, status };
+        db.run(
+          `INSERT INTO history_tbl (entry_id, user_id, action, changes) VALUES (?, ?, ?, ?)`,
+          [entry_id, user_id || null, 'UPDATE', JSON.stringify(changes)],
+          (err2) => {
+            if (err2) {
+              return db.run('ROLLBACK', () => res.status(500).json({ error: err2.message }));
+            }
+            db.run('COMMIT', (commitErr) => {
+              if (commitErr) {
+                return db.run('ROLLBACK', () => res.status(500).json({ error: commitErr.message }));
+              }
+              res.json({ message: 'Entry updated successfully' });
+            });
+          }
+        );
+      });
     });
   });
 
@@ -339,7 +563,12 @@ app.post('/api/update-letter', (req, res) => {
   const server = app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);
   });
+  return { app, db, server };
 }
 
-// Start the server when the app starts
-startServer();
+if (require.main === module) {
+  // Start the server when the app starts
+  startServer();
+}
+
+module.exports = startServer;

--- a/tests/audit.test.js
+++ b/tests/audit.test.js
@@ -1,0 +1,159 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+const sqlite3 = require('sqlite3').verbose();
+const startServer = require('../server');
+
+let serverInfo;
+let db;
+let baseUrl;
+let dbPath;
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) reject(err); else resolve(this);
+    });
+  });
+}
+
+function all(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) reject(err); else resolve(rows);
+    });
+  });
+}
+
+test.before(async () => {
+  dbPath = path.join(__dirname, 'test.db');
+  try { fs.unlinkSync(dbPath); } catch {}
+  process.env.DB_PATH = dbPath;
+  process.env.PORT = 0;
+
+  serverInfo = startServer();
+  db = serverInfo.db;
+  const port = serverInfo.server.address().port;
+  baseUrl = `http://localhost:${port}`;
+
+  await run(db, `CREATE TABLE entries_tbl (
+    entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_date TEXT NOT NULL,
+    entry_category TEXT NOT NULL,
+    file_number TEXT,
+    subject TEXT,
+    officer_assigned TEXT,
+    date_sent TEXT,
+    recieved_date TEXT,
+    letter_date TEXT,
+    reciepient TEXT,
+    letter_type TEXT,
+    folio_number TEXT,
+    file_type TEXT,
+    description TEXT,
+    status TEXT
+  );`);
+});
+
+test.after(async () => {
+  await new Promise(resolve => serverInfo.server.close(resolve));
+  db.close();
+  fs.unlinkSync(dbPath);
+});
+
+
+test.beforeEach(async () => {
+  await run(db, 'DELETE FROM entries_tbl');
+  await run(db, 'DELETE FROM history_tbl');
+});
+
+test('create file logs history', async () => {
+  const res = await fetch(`${baseUrl}/api/add-file`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      entry_date: '2024-01-01',
+      file_number: 'FN1',
+      subject: 'Sub',
+      officer_assigned: 'Officer',
+      status: 'open',
+      recieved_date: '2024-01-01',
+      date_sent: '2024-01-02',
+      file_type: 'Type',
+      user_id: 1
+    })
+  });
+  assert.strictEqual(res.status, 201);
+  const body = await res.json();
+  const rows = await all(db, 'SELECT * FROM history_tbl');
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].entry_id, body.entry_id);
+  assert.strictEqual(rows[0].user_id, 1);
+  assert.strictEqual(rows[0].action, 'CREATE');
+});
+
+test('update entry logs history', async () => {
+  const createRes = await fetch(`${baseUrl}/api/add-file`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      entry_date: '2024-01-01',
+      file_number: 'FN2',
+      subject: 'Sub',
+      officer_assigned: 'Officer',
+      status: 'open',
+      recieved_date: '2024-01-01',
+      date_sent: '2024-01-02',
+      file_type: 'Type',
+      user_id: 1
+    })
+  });
+  const created = await createRes.json();
+
+  const updateRes = await fetch(`${baseUrl}/api/update-entry`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ entry_id: created.entry_id, file_number: 'FN2A', status: 'closed', user_id: 2 })
+  });
+  assert.strictEqual(updateRes.status, 200);
+
+  const rows = await all(db, 'SELECT * FROM history_tbl ORDER BY id');
+  assert.strictEqual(rows.length, 2);
+  assert.strictEqual(rows[1].entry_id, created.entry_id);
+  assert.strictEqual(rows[1].user_id, 2);
+  assert.strictEqual(rows[1].action, 'UPDATE');
+});
+
+test('delete entry logs history', async () => {
+  const createRes = await fetch(`${baseUrl}/api/add-file`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      entry_date: '2024-01-01',
+      file_number: 'FN3',
+      subject: 'Sub',
+      officer_assigned: 'Officer',
+      status: 'open',
+      recieved_date: '2024-01-01',
+      date_sent: '2024-01-02',
+      file_type: 'Type',
+      user_id: 1
+    })
+  });
+  const created = await createRes.json();
+
+  const deleteRes = await fetch(`${baseUrl}/api/delete-entry/${created.entry_id}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: 3 })
+  });
+  assert.strictEqual(deleteRes.status, 200);
+
+  const rows = await all(db, 'SELECT * FROM history_tbl ORDER BY id');
+  assert.strictEqual(rows.length, 2);
+  assert.strictEqual(rows[1].entry_id, created.entry_id);
+  assert.strictEqual(rows[1].user_id, 3);
+  assert.strictEqual(rows[1].action, 'DELETE');
+});
+

--- a/views/pages/history.ejs
+++ b/views/pages/history.ejs
@@ -1,0 +1,48 @@
+
+<div class="history-header">
+  <div class="h3 fw-regular text-muted">History Log:</div>
+</div>
+<div class="activity2 bg-light bg-gradient" id="history-entries">
+  <div class="table2-container table-container">
+    <table class="table table-striped table-bordered table-hover display" id="history-table">
+      <thead class="thead-dark">
+        <tr>
+          <th>ID</th>
+          <th>Entry ID</th>
+          <th>User ID</th>
+          <th>Action</th>
+          <th>Changes</th>
+          <th>Timestamp</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Data dynamically populated -->
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+  function initializeDataTableforHistory() {
+    $('#history-table').DataTable({
+      ajax: {
+        url: 'http://localhost:49200/api/history',
+        dataSrc: 'data'
+      },
+      columns: [
+        { data: 'id' },
+        { data: 'entry_id' },
+        { data: 'user_id' },
+        { data: 'action' },
+        { data: 'changes' },
+        { data: 'timestamp' }
+      ],
+      dom: 'Bfrtip',
+      buttons: ['csv', 'pdf']
+    });
+  }
+
+  $(document).ready(function () {
+    initializeDataTableforHistory();
+  });
+</script>


### PR DESCRIPTION
## Summary
- create `history_tbl` and log entry modifications in SQLite transactions
- expose history records via `/api/history` and new DataTable view
- add tests ensuring CRUD actions record audit rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68915e45077883289edbbc55a658e054