### PR TITLE
refactor: centralize truncate utility

### DIFF
--- a/public/index/js/utils.js
+++ b/public/index/js/utils.js
@@ -1,0 +1,4 @@
+export function truncate(str, maxlength) {
+    return (str.length > maxlength) ?
+        str.slice(0, maxlength - 1) + '…' : str;
+}

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -193,12 +193,14 @@
   <!-- Index EJS Script -->
   <script type="text/javascript" src="../public/index/js/renderer.js"></script>
 
+  <script type="module" src="../public/index/js/utils.js"></script>
+
   <!-- Custom Scripts (Partials EJS) -->
-  <script type="text/javascript" src="./partials-public/letter-management/js/letters-renderer.js"></script>
-  <script type="text/javascript" src="./partials-public/dashboard/js/dashboard-renderer.js"></script>
-  <script type="text/javascript" src="./partials-public/reports/js/report-renderer.js"></script>
-  <script type="text/javascript" src="./partials-public/entries/js/entries-renderer.js"></script>
-  <script type="text/javascript" src="./partials-public/file-management/js/files-renderer.js"></script>"
+  <script type="module" src="./partials-public/letter-management/js/letters-renderer.js"></script>
+  <script type="module" src="./partials-public/dashboard/js/dashboard-renderer.js"></script>
+  <script type="module" src="./partials-public/reports/js/report-renderer.js"></script>
+  <script type="module" src="./partials-public/entries/js/entries-renderer.js"></script>
+  <script type="module" src="./partials-public/file-management/js/files-renderer.js"></script>
 
 
 </body>

--- a/src/partials-public/dashboard/js/dashboard-renderer.js
+++ b/src/partials-public/dashboard/js/dashboard-renderer.js
@@ -1,8 +1,4 @@
-// Define the truncate function
-function truncate(str, maxlength) {
-    return (str.length > maxlength) ?
-        str.slice(0, maxlength - 1) + '…' : str;
-}
+import { truncate } from '../../../../public/index/js/utils.js';
 
 function fetchSummations() {
     $.ajax({

--- a/src/partials-public/entries/js/entries-renderer.js
+++ b/src/partials-public/entries/js/entries-renderer.js
@@ -1,3 +1,5 @@
+import { truncate } from '../../../../public/index/js/utils.js';
+
 $(document).ready(function () {
     // Initialize components on page load
     initializeDataTableforEntries();

--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -1,3 +1,5 @@
+import { truncate } from '../../../../public/index/js/utils.js';
+
 $(document).ready(function () {
     setupFileModalActions();
     initializeDataTableforFiles();

--- a/src/partials-public/letter-management/js/letters-renderer.js
+++ b/src/partials-public/letter-management/js/letters-renderer.js
@@ -1,3 +1,5 @@
+import { truncate } from '../../../../public/index/js/utils.js';
+
 $(document).ready(function () {
     setupLetterModalActions();
     initializeDataTableforLetters();


### PR DESCRIPTION
## Summary
- add shared truncate helper
- import truncate from utils across renderers
- load utils module before renderer scripts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150e20c708328a992de252d7c745b