### PR TITLE
fix: reference delete response correctly

### DIFF
--- a/src/partials-public/letter-management/js/letters-renderer.js
+++ b/src/partials-public/letter-management/js/letters-renderer.js
@@ -80,7 +80,7 @@ function initializeDataTableforLetters() {
                     letterEntryToDelete = null;
 
                     // Optional success message
-                    console.log('Letter deleted successfully!', response);
+                    console.log('Letter deleted successfully!', result);
                 },
                 error: function (xhr, status, error) {
                     // Handle errors


### PR DESCRIPTION
## Summary
- reference AJAX delete success result correctly in letters renderer

## Testing
- `npm test` (fails: Error: no test specified)
- `node - <<'NODE'\nconst success=function(result){console.log('Letter deleted successfully!', result);};\nsuccess('test');\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_689150db8ab883289866e31341a0b51e