### PR TITLE
Remove redundant login success handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -506,16 +506,6 @@ ipcMain.on('login-attempt', (event, credentials) => {
   });
 });
 
-// Handle login success and pass userData to the main window
-ipcMain.on("login-success", (event, userData) => {
-  // Close the splash window
-  if (splashWindow) {
-    splashWindow.close();
-  }
-
-  // Create and show the main window, and pass user data
-  createMainWindow(userData);  // Pass userData when creating the main window
-});
 
 function createMainWindow(userData) {
   mainWindow = new BrowserWindow({


### PR DESCRIPTION
## Summary
- remove ipcMain `login-success` listener
- rely on `login-attempt` to close splash and open main window

## Testing
- `npm test` (fails: Error: no test specified)
- `node test script` (splash and main windows created once)


------
https://chatgpt.com/codex/tasks/task_e_68915d56a3108328ad1bc13eb9bff3c3