### PR TITLE
feat: add role-based access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Records Management System
+
+## Role-based Access Manual Checks
+
+To verify that role-based restrictions work:
+
+1. **API protection**
+   - Start the server: `node server.js`.
+   - As a non-admin user: `curl -i -H "x-user-role:user" -H "Content-Type: application/json" -d '{}' http://localhost:49200/api/add-file`.
+     The request should return `403 Forbidden`.
+   - As an admin: `curl -i -H "x-user-role:admin" -H "Content-Type: application/json" -d '{}' http://localhost:49200/api/add-file`.
+
+2. **UI visibility**
+   - Launch the application and log in as a user with a role other than `admin`.
+   - Menu items such as **Report Management** and buttons like **Add New File/Letter** should be hidden.
+

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
+const { setUser, authorize } = require('./middleware/auth');
 
 // Print userData path for debugging
 console.log('userData path:', app.getPath('userData'));
@@ -58,6 +59,7 @@ function startServer() {
   // Middleware setup
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(setUser);
 
 
   // API route for user authentication (login)
@@ -186,7 +188,7 @@ function startServer() {
   });
 
   // ADD FILE TO TABLE
-  app.post('/api/add-file', (req, res) => {
+  app.post('/api/add-file', authorize(['admin']), (req, res) => {
     const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
 
     // Check only for required fields
@@ -213,7 +215,7 @@ function startServer() {
   });
 
 // UPDATE FILE IN TABLE
-app.post('/api/update-file', (req, res) => {
+app.post('/api/update-file', authorize(['admin']), (req, res) => {
   const { 
     entry_id,
     entry_date,
@@ -284,7 +286,7 @@ app.post('/api/update-file', (req, res) => {
   });
 
   // ADD LETTER TO TABLE
-  app.post('/api/add-letter', (req, res) => {
+  app.post('/api/add-letter', authorize(['admin']), (req, res) => {
     const { entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
 
     // Check only for required fields
@@ -311,7 +313,7 @@ app.post('/api/update-file', (req, res) => {
 
 
   // UPDATE LETTER IN TABLE
-  app.post('/api/update-letter', (req, res) => {
+  app.post('/api/update-letter', authorize(['admin']), (req, res) => {
     const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
 
     // Check only for required fields
@@ -339,7 +341,7 @@ app.post('/api/update-file', (req, res) => {
 
 
   // DELETE ENTRY IN TABLE
-  app.delete('/api/delete-file/:entry_id', (req, res) => {
+  app.delete('/api/delete-file/:entry_id', authorize(['admin']), (req, res) => {
     const entryId = req.params.entry_id;
     const query = `
           DELETE FROM entries_tbl
@@ -354,7 +356,7 @@ app.post('/api/update-file', (req, res) => {
     });
   });
   // DELETE ENTRY IN TABLE
-  app.delete('/api/delete-letter/:entry_id', (req, res) => {
+  app.delete('/api/delete-letter/:entry_id', authorize(['admin']), (req, res) => {
     const entryId = req.params.entry_id;
     const query = `
           DELETE FROM entries_tbl
@@ -425,7 +427,7 @@ app.post('/api/update-file', (req, res) => {
 
 
   // Server route modifications
-  app.post('/api/update-entry', (req, res) => {
+  app.post('/api/update-entry', authorize(['admin']), (req, res) => {
     const { entry_id, file_number, status } = req.body;
     if (!entry_id || !file_number || !status) {
       return res.status(400).json({ error: 'Missing required fields' });

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,19 @@
+function setUser(req, res, next) {
+  const role = req.headers['x-user-role'];
+  if (role) {
+    req.user = { role };
+  }
+  next();
+}
+
+function authorize(allowed = []) {
+  return function (req, res, next) {
+    const userRole = req.user && req.user.role;
+    if (!userRole || !allowed.includes(userRole)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}
+
+module.exports = { setUser, authorize };

--- a/public/index/js/renderer.js
+++ b/public/index/js/renderer.js
@@ -1,15 +1,31 @@
 document.addEventListener("DOMContentLoaded", function () {
 
-  // Listen for user data sent from the main process
-  window.electronAPI.onUserData((userData) => {
-    const usernameElement = document.getElementById('username');
-    const userRoleElement = document.getElementById('user_role');
+    let currentUserRole = null;
 
-    // Update the UI with the received user data
-    usernameElement.textContent = userData.username;
-    userRoleElement.textContent = userData.role;
-  });
-  
+    // Listen for user data sent from the main process
+    window.electronAPI.onUserData((userData) => {
+        const usernameElement = document.getElementById('username');
+        const userRoleElement = document.getElementById('user_role');
+
+        // Update the UI with the received user data
+        usernameElement.textContent = userData.username;
+        userRoleElement.textContent = userData.role;
+        currentUserRole = userData.role;
+        applyRoleVisibility();
+    });
+
+    function applyRoleVisibility() {
+        if (!currentUserRole) return;
+        document.querySelectorAll('[data-role]').forEach((el) => {
+            const roles = el.getAttribute('data-role').split(',');
+            if (!roles.includes(currentUserRole)) {
+                el.style.display = 'none';
+            } else {
+                el.style.display = '';
+            }
+        });
+    }
+
     // Get the element with the class 'dashboard-link'
     const dashboardLink = document.querySelector(".dashboard-link");
 
@@ -73,6 +89,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 // Re-attach event listeners after loading new content
                 addMenuEventListeners();
                 addActivityViewEventListeners();
+                applyRoleVisibility();
 
                 // Initialize components based on the loaded view
                 if (view === 'dashboard') {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
 const path = require('path');
+const { setUser, authorize } = require('./middleware/auth');
 
 // Start Express server
 function startServer() {
@@ -21,6 +22,7 @@ function startServer() {
   // Middleware setup
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(setUser);
 
   // Define routes here
   app.get('/api/recent-entries', (req, res) => {
@@ -114,7 +116,7 @@ app.get('/api/get-files', (req, res) => {
 });
 
 // ADD FILE TO TABLE
-app.post('/api/add-file', (req, res) => {
+app.post('/api/add-file', authorize(['admin']), (req, res) => {
   const { entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, file_type, reciepient, description } = req.body;
 
   // Check only for required fields
@@ -141,7 +143,7 @@ app.post('/api/add-file', (req, res) => {
 });
 
 // UPDATE FILE IN TABLE
-app.post('/api/update-file', (req, res) => {
+app.post('/api/update-file', authorize(['admin']), (req, res) => {
   const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, date_sent, reciepient, file_type, folio_number, description } = req.body;
 
   // Check only for required fields
@@ -186,7 +188,7 @@ app.post('/api/update-file', (req, res) => {
   });
 
 // ADD LETTER TO TABLE
-app.post('/api/add-letter', (req, res) => {
+app.post('/api/add-letter', authorize(['admin']), (req, res) => {
   const { entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
 
   // Check only for required fields
@@ -213,7 +215,7 @@ app.post('/api/add-letter', (req, res) => {
 
 
   // UPDATE LETTER IN TABLE
-app.post('/api/update-letter', (req, res) => {
+app.post('/api/update-letter', authorize(['admin']), (req, res) => {
   const { entry_id, entry_date, file_number, subject, officer_assigned, status, recieved_date, letter_date, letter_type, folio_number, description } = req.body;
 
   // Check only for required fields
@@ -241,7 +243,7 @@ app.post('/api/update-letter', (req, res) => {
 
 
   // DELETE ENTRY IN TABLE
-  app.delete('/api/delete-entry/:entry_id', (req, res) => {
+  app.delete('/api/delete-entry/:entry_id', authorize(['admin']), (req, res) => {
     const entryId = req.params.entry_id;
     const query = `
           DELETE FROM entries_tbl
@@ -313,7 +315,7 @@ app.post('/api/update-letter', (req, res) => {
 
 
   // Server route modifications
-  app.post('/api/update-entry', (req, res) => {
+  app.post('/api/update-entry', authorize(['admin']), (req, res) => {
     const { entry_id, file_number, status } = req.body;
     if (!entry_id || !file_number || !status) {
       return res.status(400).json({ error: 'Missing required fields' });

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -129,7 +129,7 @@
 
           <!-- List Item For Report Management -->
           <li>
-            <div id="menu-reports" class="reports-link menu-list" data-content-url="reports">
+            <div id="menu-reports" class="reports-link menu-list" data-content-url="reports" data-role="admin">
               Report Management
             </div>
           </li>

--- a/views/pages/file-management.ejs
+++ b/views/pages/file-management.ejs
@@ -3,7 +3,7 @@
     <div class="h3 fw-regular text-muted">File Management:</div>
     <!-- Add File Button -->
     <div class="row mb-3">
-        <div class="col-md-6 text-end">
+        <div class="col-md-6 text-end" data-role="admin">
             <button class="btn btn-primary" id="new-file" onclick="setupFileModalActions()">Add New File</button>
         </div>
     </div>

--- a/views/pages/letter-management.ejs
+++ b/views/pages/letter-management.ejs
@@ -2,7 +2,7 @@
     <div class="h3 fw-regular text-muted">Letter Management:</div>
     <!-- Search and Add Letter Button -->
     <div class="row mb-3">
-        <div class="col-md-6 text-end">
+        <div class="col-md-6 text-end" data-role="admin">
             <button class="btn btn-primary" id="new-letter" onclick="setupLetterModalActions()">Add New Letter</button>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add authorization middleware for checking user roles
- hide admin-only UI sections when role lacks permission
- document and verify manual role-based access checks

## Testing
- `npm test` (fails: Error: no test specified)
- `curl -i -H "x-user-role:user" -H "Content-Type: application/json" -d '{}' http://localhost:49200/api/add-file`


------
https://chatgpt.com/codex/tasks/task_e_68915db394cc832880916112b42c87a5