### PR TITLE
Fix recipient reset in file modal

### DIFF
--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -186,7 +186,7 @@ function clearFileModalFields() {
     $('#recieved_date').val('');
     $('#date_sent').val('');
     $('#file_type').val('');
-    $('#reciepient').val('');
+    $('#reciepient_name').val('');
     $('#description').val('');
     $('#status').val('');
     $('#fileForm').data('entry_id', null);


### PR DESCRIPTION
## Summary
- ensure clearFileModalFields resets recipient input using correct ID

## Testing
- `node <<'NODE' ... NODE`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150ce883c8328b207b3015533f096