### PR TITLE
Enable SQLite foreign key enforcement

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,6 +48,7 @@ const db = new sqlite3.Database(dbPath, (err) => {
     console.error('Error connecting to the database:', err.message);
   } else {
     console.log('Connected to the SQLite database at', dbPath);
+    db.exec('PRAGMA foreign_keys = ON');
   }
 });
 // Start Express server

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ function startServer() {
       console.error('Error connecting to the database:', err.message);
     } else {
       console.log('Connected to the SQLite database.');
+      db.exec('PRAGMA foreign_keys = ON');
     }
   });
 


### PR DESCRIPTION
## Summary
- Enable SQLite foreign key checks after database connections in main and server.
- Reviewed existing database schema for defined foreign key relationships.

## Testing
- `sqlite3 database/recordsmgmtsys.db ".schema"`
- `sqlite3 database/recordsmgmtsys.db "PRAGMA foreign_keys=ON; INSERT INTO fk_test(user_id) VALUES (999);"` (foreign key constraint failure)
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68915d72a1bc8328a60ec826edd41b89