### PR TITLE
refactor: replace jquery ajax with fetch

### DIFF
--- a/src/partials-public/dashboard/js/dashboard-renderer.js
+++ b/src/partials-public/dashboard/js/dashboard-renderer.js
@@ -4,22 +4,19 @@ function truncate(str, maxlength) {
         str.slice(0, maxlength - 1) + '…' : str;
 }
 
-function fetchSummations() {
-    $.ajax({
-        url: 'http://localhost:49200/api/summations',
-        type: 'GET',
-        success: function (data) {
-            $('#entries-count').text(data.total_entries);
-            $('#letters-count').text(data.total_letters);
-            $('#files-count').text(data.total_files);
-        },
-        error: function (xhr, status, error) {
-            console.error("Error fetching summations:", error);
-            $('#entries-count').text('Error');
-            $('#letters-count').text('Error');
-            $('#files-count').text('Error');
-        }
-    });
+async function fetchSummations() {
+    try {
+        const response = await fetch('http://localhost:49200/api/summations');
+        const data = await response.json();
+        $('#entries-count').text(data.total_entries);
+        $('#letters-count').text(data.total_letters);
+        $('#files-count').text(data.total_files);
+    } catch (error) {
+        console.error("Error fetching summations:", error);
+        $('#entries-count').text('Error');
+        $('#letters-count').text('Error');
+        $('#files-count').text('Error');
+    }
 }
 
 $(document).ready(function () {
@@ -38,7 +35,7 @@ $(document).ready(function () {
         }, 500); // Timeout matches the CSS transition duration
     });
 
-    $('#entryForm').on('submit', function (e) {
+    $('#entryForm').on('submit', async function (e) {
         e.preventDefault();
 
         const entryData = {
@@ -47,20 +44,19 @@ $(document).ready(function () {
             status: $('#status').val()
         };
 
-        $.ajax({
-            url: 'http://localhost:49200/api/update-entry',
-            type: 'POST',
-            data: JSON.stringify(entryData),
-            contentType: 'application/json',
-            success: function (response) {
-                console.log("Entry updated successfully:", response);
-                $('#entryModal').modal('hide');
-                $('#recentEntriesTable').DataTable().ajax.reload();
-            },
-            error: function (xhr, status, error) {
-                console.error("Error updating entry:", error);
-            }
-        });
+        try {
+            const response = await fetch('http://localhost:49200/api/update-entry', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(entryData)
+            });
+            const result = await response.json();
+            console.log("Entry updated successfully:", result);
+            $('#entryModal').modal('hide');
+            $('#recentEntriesTable').DataTable().ajax.reload();
+        } catch (error) {
+            console.error("Error updating entry:", error);
+        }
     });
 });
 

--- a/src/partials-public/entries/js/entries-renderer.js
+++ b/src/partials-public/entries/js/entries-renderer.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
     initializeDataTableforEntries();
 
     // Handle form submission for updating entries
-    $('#entryForm').on('submit', function (e) {
+    $('#entryForm').on('submit', async function (e) {
         e.preventDefault();
 
         const entryData = {
@@ -12,20 +12,19 @@ $(document).ready(function () {
             status: $('#status').val()
         };
 
-        $.ajax({
-            url: 'http://localhost:49200/api/update-entry',
-            type: 'POST',
-            data: JSON.stringify(entryData),
-            contentType: 'application/json',
-            success: function (response) {
-                console.log("Entry updated successfully:", response);
-                $('#entryModal').modal('hide');
-                $('#letters-table').DataTable().ajax.reload(); // Reload table to reflect changes
-            },
-            error: function (xhr, status, error) {
-                console.error("Error updating entry:", error);
-            }
-        });
+        try {
+            const response = await fetch('http://localhost:49200/api/update-entry', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(entryData)
+            });
+            const result = await response.json();
+            console.log("Entry updated successfully:", result);
+            $('#entryModal').modal('hide');
+            $('#letters-table').DataTable().ajax.reload(); // Reload table to reflect changes
+        } catch (error) {
+            console.error("Error updating entry:", error);
+        }
     });
 });
 

--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -69,21 +69,20 @@ function initializeDataTableforFiles() {
     });
 
     // Handle the confirm button click inside the delete modal
-    $('#confirmDelete').on('click', function () {
+    $('#confirmDelete').on('click', async function () {
         if (fileEntryToDelete) {
-            $.ajax({
-                url: `http://localhost:49200/api/delete-file/${fileEntryToDelete}`,
-                type: 'DELETE',
-                success: function (response) {
-                    console.log("File deleted successfully:", response);
-                    $('#file-table').DataTable().ajax.reload();
-                    $('#deleteModal').modal('hide');
-                    fileEntryToDelete = null;
-                },
-                error: function (xhr, status, error) {
-                    console.error("Error deleting file:", error);
-                }
-            });
+            try {
+                const response = await fetch(`http://localhost:49200/api/delete-file/${fileEntryToDelete}`, {
+                    method: 'DELETE'
+                });
+                const result = await response.json();
+                console.log("File deleted successfully:", result);
+                $('#file-table').DataTable().ajax.reload();
+                $('#deleteModal').modal('hide');
+                fileEntryToDelete = null;
+            } catch (error) {
+                console.error("Error deleting file:", error);
+            }
         }
     });
 
@@ -101,41 +100,39 @@ function setupFileModalActions() {
     });
 
     // Remove existing event listeners and attach a new one for "Save"
-    $('#save-file').off('click').on('click', function () {
+    $('#save-file').off('click').on('click', async function () {
         const fileData = getFileFormData();
-        $.ajax({
-            url: 'http://localhost:49200/api/add-file',
-            type: 'POST',
-            data: JSON.stringify(fileData),
-            contentType: 'application/json',
-            success: function (response) {
-                console.log("File added successfully:", response);
-                $('#fileModal').modal('hide');
-                $('#file-table').DataTable().ajax.reload();
-            },
-            error: function (xhr, status, error) {
-                console.error("Error adding file:", error);
-            }
-        });
+        try {
+            const response = await fetch('http://localhost:49200/api/add-file', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(fileData)
+            });
+            const result = await response.json();
+            console.log("File added successfully:", result);
+            $('#fileModal').modal('hide');
+            $('#file-table').DataTable().ajax.reload();
+        } catch (error) {
+            console.error("Error adding file:", error);
+        }
     });
 
     // Remove existing event listeners and attach a new one for "Update"
-    $('#update-file').off('click').on('click', function () {
+    $('#update-file').off('click').on('click', async function () {
         const fileData = getFileFormData();
-        $.ajax({
-            url: 'http://localhost:49200/api/update-file',
-            type: 'POST',
-            data: JSON.stringify(fileData),
-            contentType: 'application/json',
-            success: function (response) {
-                console.log("File updated successfully:", response);
-                $('#fileModal').modal('hide');
-                $('#file-table').DataTable().ajax.reload();
-            },
-            error: function (xhr, status, error) {
-                console.error("Error updating file:", error);
-            }
-        });
+        try {
+            const response = await fetch('http://localhost:49200/api/update-file', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(fileData)
+            });
+            const result = await response.json();
+            console.log("File updated successfully:", result);
+            $('#fileModal').modal('hide');
+            $('#file-table').DataTable().ajax.reload();
+        } catch (error) {
+            console.error("Error updating file:", error);
+        }
     });
 }
 

--- a/src/partials-public/letter-management/js/letters-renderer.js
+++ b/src/partials-public/letter-management/js/letters-renderer.js
@@ -68,25 +68,21 @@ function initializeDataTableforLetters() {
     });
 
     // Handle delete confirmation
-    $('#confirmDelete').on('click', function () {
+    $('#confirmDelete').on('click', async function () {
         if (letterEntryToDelete) {
-            $.ajax({
-                url: `http://localhost:49200/api/delete-letter/${letterEntryToDelete}`,
-                type: 'DELETE',
-                success: function (result) {
-                    // Reload DataTable and hide the modal
-                    $('#letters-table').DataTable().ajax.reload();
-                    $('#deleteModal').modal('hide');
-                    letterEntryToDelete = null;
-
-                    // Optional success message
-                    console.log('Letter deleted successfully!', response);
-                },
-                error: function (xhr, status, error) {
-                    // Handle errors
-                    console.error("Error deleting letter:", error);
-                }
-            });
+            try {
+                const response = await fetch(`http://localhost:49200/api/delete-letter/${letterEntryToDelete}`, {
+                    method: 'DELETE'
+                });
+                const result = await response.json();
+                $('#letters-table').DataTable().ajax.reload();
+                $('#deleteModal').modal('hide');
+                letterEntryToDelete = null;
+                console.log('Letter deleted successfully!', result);
+            } catch (error) {
+                // Handle errors
+                console.error("Error deleting letter:", error);
+            }
         }
     });
 
@@ -103,41 +99,39 @@ function setupLetterModalActions() {
     });
 
     // Remove existing event listeners and attach a new one for "Save"
-    $('#save-letter').off('click').on('click', function () {
+    $('#save-letter').off('click').on('click', async function () {
         const letterData = getLetterFormData();
-        $.ajax({
-            url: 'http://localhost:49200/api/add-letter',
-            type: 'POST',
-            data: JSON.stringify(letterData),
-            contentType: 'application/json',
-            success: function (response) {
-                console.log("Letter added successfully:", response);
-                $('#letterModal').modal('hide');
-                $('#letters-table').DataTable().ajax.reload();
-            },
-            error: function (xhr, status, error) {
-                console.error("Error adding letter:", error);
-            }
-        });
+        try {
+            const response = await fetch('http://localhost:49200/api/add-letter', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(letterData)
+            });
+            const result = await response.json();
+            console.log("Letter added successfully:", result);
+            $('#letterModal').modal('hide');
+            $('#letters-table').DataTable().ajax.reload();
+        } catch (error) {
+            console.error("Error adding letter:", error);
+        }
     });
 
     // Remove existing event listeners and attach a new one for "Update"
-    $('#update-letter').off('click').on('click', function () {
+    $('#update-letter').off('click').on('click', async function () {
         const letterData = getLetterFormData();
-        $.ajax({
-            url: 'http://localhost:49200/api/update-letter',
-            type: 'POST',
-            data: JSON.stringify(letterData),
-            contentType: 'application/json',
-            success: function (response) {
-                console.log("Letter updated successfully:", response);
-                $('#letterModal').modal('hide');
-                $('#letters-table').DataTable().ajax.reload();
-            },
-            error: function (xhr, status, error) {
-                console.error("Error updating letter:", error);
-            }
-        });
+        try {
+            const response = await fetch('http://localhost:49200/api/update-letter', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(letterData)
+            });
+            const result = await response.json();
+            console.log("Letter updated successfully:", result);
+            $('#letterModal').modal('hide');
+            $('#letters-table').DataTable().ajax.reload();
+        } catch (error) {
+            console.error("Error updating letter:", error);
+        }
     });
 }
 

--- a/src/partials-public/reports/js/report-renderer.js
+++ b/src/partials-public/reports/js/report-renderer.js
@@ -1,39 +1,37 @@
-$(document).ready(function () {
-    $('#generate-report').on('click', function () {
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('generate-report').addEventListener('click', () => {
         generateReport();
     });
 
-    $('#export-pdf').on('click', function () {
+    document.getElementById('export-pdf').addEventListener('click', () => {
         exportPDF();
     });
 });
 
-function generateReport() {
-    const startDate = $('#start-date').val();
-    const endDate = $('#end-date').val();
-    const officerAssigned = $('#officer-assigned').val();
-    const status = $('#status').val();
-    const fileNumber = $('#file-number').val();
-    const category = $('#category').val();
+async function generateReport() {
+    const startDate = document.getElementById('start-date').value;
+    const endDate = document.getElementById('end-date').value;
+    const officerAssigned = document.getElementById('officer-assigned').value;
+    const status = document.getElementById('status').value;
+    const fileNumber = document.getElementById('file-number').value;
+    const category = document.getElementById('category').value;
 
-    $.ajax({
-        url: 'http://localhost:49200/api/make-reports',
-        method: 'GET',
-        data: {
-            start_date: startDate,
-            end_date: endDate,
-            officer_assigned: officerAssigned,
-            status: status,
-            file_number: fileNumber,
-            category: category
-        },
-        success: function (data) {
-            $('#report-content').html(renderReport(data));
-        },
-        error: function () {
-            alert('Failed to generate report.');
-        }
+    const params = new URLSearchParams({
+        start_date: startDate,
+        end_date: endDate,
+        officer_assigned: officerAssigned,
+        status: status,
+        file_number: fileNumber,
+        category: category
     });
+
+    try {
+        const response = await fetch(`http://localhost:49200/api/make-reports?${params.toString()}`);
+        const data = await response.json();
+        document.getElementById('report-content').innerHTML = renderReport(data);
+    } catch (error) {
+        alert('Failed to generate report.');
+    }
 }
 
 function renderReport(data) {


### PR DESCRIPTION
## Summary
- replace jQuery $.ajax calls in public renderer scripts with async/await fetch
- drop jQuery usage from reports renderer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68915da9035c832887b14881cfa8c74c