### PR TITLE
feat: centralize API base URL

### DIFF
--- a/public/index/js/config.js
+++ b/public/index/js/config.js
@@ -1,0 +1,45 @@
+// Configuration for API base URL shared across client scripts
+// Default base URL
+const DEFAULT_API_BASE_URL = 'http://localhost:49200';
+
+let apiBaseUrl = DEFAULT_API_BASE_URL;
+
+// Allow override via environment variable
+if (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) {
+  apiBaseUrl = process.env.API_BASE_URL;
+} else if (typeof require === 'function') {
+  // Attempt to read from settings.json if available
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const candidatePaths = [
+      path.resolve(__dirname, '../../settings.json'),
+      path.resolve(__dirname, '../../../settings.json')
+    ];
+
+    for (const settingsPath of candidatePaths) {
+      if (fs.existsSync(settingsPath)) {
+        const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        if (settings.API_BASE_URL) {
+          apiBaseUrl = settings.API_BASE_URL;
+          break;
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Failed to load API base URL from settings.json', err);
+  }
+}
+
+const API_BASE_URL = apiBaseUrl;
+
+// Expose globally for browser scripts
+if (typeof window !== 'undefined') {
+  window.API_BASE_URL = API_BASE_URL;
+}
+
+// Export for CommonJS environments if needed
+if (typeof module !== 'undefined') {
+  module.exports = { API_BASE_URL };
+}
+

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -190,6 +190,9 @@
   <script type="text/javascript" src="../node_modules/@popperjs/core/dist/umd/popper-base.min.js"></script>
   <script type="text/javascript" src="../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 
+  <!-- Shared config -->
+  <script type="text/javascript" src="../public/index/js/config.js"></script>
+
   <!-- Index EJS Script -->
   <script type="text/javascript" src="../public/index/js/renderer.js"></script>
 
@@ -198,7 +201,7 @@
   <script type="text/javascript" src="./partials-public/dashboard/js/dashboard-renderer.js"></script>
   <script type="text/javascript" src="./partials-public/reports/js/report-renderer.js"></script>
   <script type="text/javascript" src="./partials-public/entries/js/entries-renderer.js"></script>
-  <script type="text/javascript" src="./partials-public/file-management/js/files-renderer.js"></script>"
+  <script type="text/javascript" src="./partials-public/file-management/js/files-renderer.js"></script>
 
 
 </body>

--- a/src/partials-public/dashboard/js/dashboard-renderer.js
+++ b/src/partials-public/dashboard/js/dashboard-renderer.js
@@ -6,7 +6,7 @@ function truncate(str, maxlength) {
 
 function fetchSummations() {
     $.ajax({
-        url: 'http://localhost:49200/api/summations',
+        url: `${API_BASE_URL}/api/summations`,
         type: 'GET',
         success: function (data) {
             $('#entries-count').text(data.total_entries);
@@ -48,7 +48,7 @@ $(document).ready(function () {
         };
 
         $.ajax({
-            url: 'http://localhost:49200/api/update-entry',
+            url: `${API_BASE_URL}/api/update-entry`,
             type: 'POST',
             data: JSON.stringify(entryData),
             contentType: 'application/json',
@@ -67,7 +67,7 @@ $(document).ready(function () {
 function initializeDataTable() {
     $('#recentEntriesTable').DataTable({
         "ajax": {
-            "url": "http://localhost:49200/api/recent-entries",
+            "url": `${API_BASE_URL}/api/recent-entries`,
             "dataSrc": function (json) {
                 console.log("AJAX Response:", json);
                 return json.data;

--- a/src/partials-public/entries/js/entries-renderer.js
+++ b/src/partials-public/entries/js/entries-renderer.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
         };
 
         $.ajax({
-            url: 'http://localhost:49200/api/update-entry',
+            url: `${API_BASE_URL}/api/update-entry`,
             type: 'POST',
             data: JSON.stringify(entryData),
             contentType: 'application/json',
@@ -32,7 +32,7 @@ $(document).ready(function () {
 function initializeDataTableforEntries() {
     const entriesTable = $('#entries-table').DataTable({
         "ajax": {
-            "url": "http://localhost:49200/api/recent-entries-full",
+            "url": `${API_BASE_URL}/api/recent-entries-full`,
             "dataSrc": function (json) {
                 console.log("AJAX Response:", json);
                 return json.data; // Adjust based on your API response

--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
 function initializeDataTableforFiles() {
     const filesTable = $('#file-table').DataTable({
         ajax: {
-            url: "http://localhost:49200/api/get-files",
+            url: `${API_BASE_URL}/api/get-files`,
             dataSrc: function (json) {
                 return json.data;
             }
@@ -72,7 +72,7 @@ function initializeDataTableforFiles() {
     $('#confirmDelete').on('click', function () {
         if (fileEntryToDelete) {
             $.ajax({
-                url: `http://localhost:49200/api/delete-file/${fileEntryToDelete}`,
+                url: `${API_BASE_URL}/api/delete-file/${fileEntryToDelete}`,
                 type: 'DELETE',
                 success: function (response) {
                     console.log("File deleted successfully:", response);
@@ -104,7 +104,7 @@ function setupFileModalActions() {
     $('#save-file').off('click').on('click', function () {
         const fileData = getFileFormData();
         $.ajax({
-            url: 'http://localhost:49200/api/add-file',
+            url: `${API_BASE_URL}/api/add-file`,
             type: 'POST',
             data: JSON.stringify(fileData),
             contentType: 'application/json',
@@ -123,7 +123,7 @@ function setupFileModalActions() {
     $('#update-file').off('click').on('click', function () {
         const fileData = getFileFormData();
         $.ajax({
-            url: 'http://localhost:49200/api/update-file',
+            url: `${API_BASE_URL}/api/update-file`,
             type: 'POST',
             data: JSON.stringify(fileData),
             contentType: 'application/json',

--- a/src/partials-public/letter-management/js/letters-renderer.js
+++ b/src/partials-public/letter-management/js/letters-renderer.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
 function initializeDataTableforLetters() {
     const lettersTable = $('#letters-table').DataTable({
         ajax: {
-            url: "http://localhost:49200/api/get-letters",
+            url: `${API_BASE_URL}/api/get-letters`,
             dataSrc: function (json) {
                 return json.data;
             }
@@ -71,7 +71,7 @@ function initializeDataTableforLetters() {
     $('#confirmDelete').on('click', function () {
         if (letterEntryToDelete) {
             $.ajax({
-                url: `http://localhost:49200/api/delete-letter/${letterEntryToDelete}`,
+                url: `${API_BASE_URL}/api/delete-letter/${letterEntryToDelete}`,
                 type: 'DELETE',
                 success: function (result) {
                     // Reload DataTable and hide the modal
@@ -106,7 +106,7 @@ function setupLetterModalActions() {
     $('#save-letter').off('click').on('click', function () {
         const letterData = getLetterFormData();
         $.ajax({
-            url: 'http://localhost:49200/api/add-letter',
+            url: `${API_BASE_URL}/api/add-letter`,
             type: 'POST',
             data: JSON.stringify(letterData),
             contentType: 'application/json',
@@ -125,7 +125,7 @@ function setupLetterModalActions() {
     $('#update-letter').off('click').on('click', function () {
         const letterData = getLetterFormData();
         $.ajax({
-            url: 'http://localhost:49200/api/update-letter',
+            url: `${API_BASE_URL}/api/update-letter`,
             type: 'POST',
             data: JSON.stringify(letterData),
             contentType: 'application/json',

--- a/src/partials-public/reports/js/report-renderer.js
+++ b/src/partials-public/reports/js/report-renderer.js
@@ -17,7 +17,7 @@ function generateReport() {
     const category = $('#category').val();
 
     $.ajax({
-        url: 'http://localhost:49200/api/make-reports',
+        url: `${API_BASE_URL}/api/make-reports`,
         method: 'GET',
         data: {
             start_date: startDate,


### PR DESCRIPTION
## Summary
- add shared config exporting `API_BASE_URL` with env and `settings.json` overrides
- load config before renderer scripts
- replace hard-coded localhost URLs with `API_BASE_URL`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689150b5a2c08328999aed9dd571a819