### PR TITLE
Handle port conflicts during server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Records Management System
+
+## Port Conflict Handling
+
+The application attempts to start its Express server on the port defined by the `PORT` environment variable (default `49200`).
+If the port is already in use, the server logs a friendly message and automatically retries on the next port number until an
+available port is found.

--- a/main.js
+++ b/main.js
@@ -51,9 +51,9 @@ const db = new sqlite3.Database(dbPath, (err) => {
   }
 });
 // Start Express server
-function startServer() {
+function startServer(port = process.env.PORT || 49200) {
   const app = express();
-  const PORT = process.env.PORT || 49200;
+  const PORT = port;
 
   // Middleware setup
   app.use(bodyParser.json());
@@ -450,6 +450,15 @@ app.post('/api/update-file', (req, res) => {
   // Start the server and handle potential port conflict
   const server = app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);
+  });
+
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`Port ${PORT} is in use, trying port ${PORT + 1}...`);
+      startServer(PORT + 1);
+    } else {
+      console.error("Server error:", err);
+    }
   });
 }
 

--- a/server.js
+++ b/server.js
@@ -4,9 +4,9 @@ const bodyParser = require('body-parser');
 const path = require('path');
 
 // Start Express server
-function startServer() {
+function startServer(port = process.env.PORT || 49200) {
   const app = express();
-  const PORT = process.env.PORT || 49200;
+  const PORT = port;
 
   // Path to the SQLite database
   const dbPath = path.resolve(__dirname, './database/recordsmgmtsys.db');
@@ -338,6 +338,15 @@ app.post('/api/update-letter', (req, res) => {
   // Start the server and handle potential port conflict
   const server = app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);
+  });
+
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`Port ${PORT} is in use, trying port ${PORT + 1}...`);
+      startServer(PORT + 1);
+    } else {
+      console.error("Server error:", err);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Add port conflict handling to Express servers in `main.js` and `server.js`
- Retry on `EADDRINUSE` by incrementing the port number
- Document port conflict behavior in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68915d5243e083289350f480619b82bf