### PR TITLE
feat: add indexes migration script

### DIFF
--- a/config/add-indexes.js
+++ b/config/add-indexes.js
@@ -1,0 +1,38 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+// Path to SQLite database
+const dbPath = path.resolve(__dirname, '../database/recordsmgmtsys.db');
+const db = new sqlite3.Database(dbPath, (err) => {
+  if (err) {
+    console.error('Failed to connect to database:', err.message);
+    process.exit(1);
+  }
+});
+
+// Create indexes to optimize frequent queries
+const statements = [
+  `CREATE INDEX IF NOT EXISTS idx_entries_entry_date ON entries_tbl(entry_date);`,
+  `CREATE INDEX IF NOT EXISTS idx_entries_file_number ON entries_tbl(file_number);`,
+  `CREATE INDEX IF NOT EXISTS idx_entries_entry_category ON entries_tbl(entry_category);`
+];
+
+db.serialize(() => {
+  statements.forEach((sql) => {
+    db.run(sql, (err) => {
+      if (err) {
+        console.error('Error executing statement:', sql, err.message);
+      } else {
+        console.log('Executed:', sql);
+      }
+    });
+  });
+});
+
+db.close((err) => {
+  if (err) {
+    console.error('Error closing database:', err.message);
+  } else {
+    console.log('Indexes migration completed.');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "build": "webpack",
-    "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json"
+    "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json",
+    "migrate-indexes": "node config/add-indexes.js"
   },
   "keywords": [
     "records",


### PR DESCRIPTION
## Summary
- add migration to create indexes on entry_date, file_number, and entry_category
- expose `migrate-indexes` npm script

## Testing
- `npm run migrate-indexes`
- `npm test` *(fails: no test specified)*
- `npx autocannon -c 50 -d 10 http://localhost:49200/api/recent-entries` before and after
- `npx autocannon -c 50 -d 10 http://localhost:49200/api/make-reports` before and after

------
https://chatgpt.com/codex/tasks/task_e_68915d82f7548328b40419709a5663ba