### PR TITLE
feat: add database initialization and backup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ coverage/
 /dist
 /build
 
+# Database backups
+/database/backups/
+
 # Environment variables
 .env
 

--- a/config/init-database.js
+++ b/config/init-database.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+// Default locations
+const dbDirectory = path.resolve(__dirname, '../database');
+const defaultDbPath = path.join(dbDirectory, 'recordsmgmtsys.db');
+const backupsDir = path.join(dbDirectory, 'backups');
+
+/**
+ * Initialize the SQLite database. Creates the database file and
+ * required tables if they do not already exist.
+ * @param {string} [dbPath] Optional path to the database file.
+ * @returns {sqlite3.Database} Connected database instance.
+ */
+function initializeDatabase(dbPath = defaultDbPath) {
+  const dir = path.dirname(dbPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const db = new sqlite3.Database(dbPath);
+
+  db.serialize(() => {
+    // entries_tbl
+    db.run(`CREATE TABLE IF NOT EXISTS entries_tbl (
+      entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      entry_date TEXT NOT NULL,
+      entry_category TEXT NOT NULL,
+      file_number TEXT,
+      subject TEXT,
+      officer_assigned TEXT,
+      date_sent TEXT,
+      recieved_date TEXT,
+      letter_date TEXT,
+      reciepient TEXT,
+      letter_type TEXT,
+      folio_number TEXT,
+      file_type TEXT,
+      description TEXT,
+      status TEXT
+    );`);
+
+    // users_tbl
+    db.run(`CREATE TABLE IF NOT EXISTS users_tbl (
+      user_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL,
+      password TEXT NOT NULL,
+      user_role TEXT NOT NULL,
+      user_creation_date TEXT
+    );`);
+  });
+
+  return db;
+}
+
+/**
+ * Create a timestamped backup of the database file.
+ * The backup files are stored in database/backups directory.
+ * @param {string} [dbPath]
+ * @returns {string} Path to the created backup file.
+ */
+function backupDatabase(dbPath = defaultDbPath) {
+  if (!fs.existsSync(dbPath)) {
+    throw new Error('Database file does not exist.');
+  }
+
+  if (!fs.existsSync(backupsDir)) {
+    fs.mkdirSync(backupsDir, { recursive: true });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
+  const backupPath = path.join(backupsDir, `recordsmgmtsys-${timestamp}.db`);
+  fs.copyFileSync(dbPath, backupPath);
+  return backupPath;
+}
+
+/**
+ * Restore the database from a backup file. The backup can be specified
+ * either as an absolute path or as a file name inside the backups directory.
+ * @param {string} backupFile Path or file name of the backup to restore.
+ * @param {string} [dbPath]
+ */
+function restoreDatabase(backupFile, dbPath = defaultDbPath) {
+  if (!backupFile) {
+    throw new Error('Backup file must be specified.');
+  }
+
+  const source = path.isAbsolute(backupFile)
+    ? backupFile
+    : path.join(backupsDir, backupFile);
+
+  if (!fs.existsSync(source)) {
+    throw new Error('Backup file does not exist.');
+  }
+
+  fs.copyFileSync(source, dbPath);
+}
+
+module.exports = {
+  initializeDatabase,
+  backupDatabase,
+  restoreDatabase,
+  defaultDbPath,
+};

--- a/main.js
+++ b/main.js
@@ -6,8 +6,8 @@ const fs = require("fs");
 
 // SERVER ROUTES
 const express = require('express');
-const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
+const { initializeDatabase } = require('./config/init-database');
 
 // Print userData path for debugging
 console.log('userData path:', app.getPath('userData'));
@@ -42,14 +42,8 @@ if (app.isPackaged) {
   console.log('Development mode DB Path:', dbPath); // Debugging the development path
 }
 
-// Initialize the database
-const db = new sqlite3.Database(dbPath, (err) => {
-  if (err) {
-    console.error('Error connecting to the database:', err.message);
-  } else {
-    console.log('Connected to the SQLite database at', dbPath);
-  }
-});
+// Initialize the database and ensure schema exists
+const db = initializeDatabase(dbPath);
 // Start Express server
 function startServer() {
   const app = express();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "build": "webpack",
-    "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json"
+    "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json",
+    "db:backup": "node scripts/db-backup.js backup",
+    "db:restore": "node scripts/db-backup.js restore"
   },
   "keywords": [
     "records",

--- a/scripts/db-backup.js
+++ b/scripts/db-backup.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { backupDatabase, restoreDatabase, defaultDbPath } = require('../config/init-database');
+
+const [,, command, arg] = process.argv;
+
+function printUsage() {
+  console.log('Usage: node scripts/db-backup.js <backup|restore> [backup-file]');
+}
+
+try {
+  if (command === 'backup') {
+    const file = backupDatabase(defaultDbPath);
+    console.log(`Backup created at ${file}`);
+  } else if (command === 'restore') {
+    if (!arg) {
+      console.error('Please specify the backup file to restore.');
+      printUsage();
+      process.exit(1);
+    }
+    const backupPath = path.resolve(arg);
+    restoreDatabase(backupPath, defaultDbPath);
+    console.log(`Database restored from ${backupPath}`);
+  } else {
+    printUsage();
+    process.exit(1);
+  }
+} catch (err) {
+  console.error('Error:', err.message);
+  process.exit(1);
+}

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
-const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
 const path = require('path');
+const { initializeDatabase } = require('./config/init-database');
 
 // Start Express server
 function startServer() {
@@ -10,13 +10,7 @@ function startServer() {
 
   // Path to the SQLite database
   const dbPath = path.resolve(__dirname, './database/recordsmgmtsys.db');
-  const db = new sqlite3.Database(dbPath, (err) => {
-    if (err) {
-      console.error('Error connecting to the database:', err.message);
-    } else {
-      console.log('Connected to the SQLite database.');
-    }
-  });
+  const db = initializeDatabase(dbPath);
 
   // Middleware setup
   app.use(bodyParser.json());


### PR DESCRIPTION
## Summary
- ensure SQLite schema is created on startup and supply backup/restore helpers
- wire initialization into main and server entrypoints
- add CLI and npm scripts for backing up or restoring the database

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run db:backup`
- `npm run db:restore -- database/backups/recordsmgmtsys-20250805012644.db`


------
https://chatgpt.com/codex/tasks/task_e_68915cefe2a88328a7c3eb859d0ebeb1