### PR TITLE
Reintroduce sign-out flow with session clearing

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, session } = require("electron");
 const path = require("path");
 const ejs = require("ejs-electron");
 const { autoUpdater } = require("electron-updater");
@@ -543,21 +543,28 @@ function createMainWindow(userData) {
   });
 }
 
-// // Handle the 'sign-out' event from the renderer
-// ipcMain.on('sign-out', () => {
-//   // Close the main window
-//   if (mainWindow) {
-//       mainWindow.close();
-//       mainWindow = null; // Clear the reference
-//   }
+// Handle the 'sign-out' event from the renderer
+ipcMain.on('sign-out', async () => {
+  // Clear session data and close the main window
+  if (mainWindow) {
+    try {
+      await session.defaultSession.clearStorageData();
+      await session.defaultSession.clearCache();
+    } catch (error) {
+      console.error('Error clearing session data:', error);
+    }
 
-//   // Reopen the splash window
-//   if (!splashWindow) {
-//       createSplashWindow();
-//   } else {
-//       splashWindow.show();
-//   }
-// });
+    mainWindow.close();
+    mainWindow = null; // Clear the reference
+  }
+
+  // Reopen the splash window
+  if (!splashWindow) {
+    createSplashWindow();
+  } else {
+    splashWindow.show();
+  }
+});
 
 app.whenReady().then(createSplashWindow);
 

--- a/preload.js
+++ b/preload.js
@@ -4,5 +4,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   sendLoginAttempt: (credentials) => ipcRenderer.send('login-attempt', credentials),
   onLoginResponse: (callback) => ipcRenderer.on('login-response', (event, response) => callback(response)),
-  onUserData: (callback) => ipcRenderer.on('user-data', (event, userData) => callback(userData))
+  onUserData: (callback) => ipcRenderer.on('user-data', (event, userData) => callback(userData)),
+  signOut: () => ipcRenderer.send('sign-out')
 });

--- a/public/index/js/renderer.js
+++ b/public/index/js/renderer.js
@@ -18,6 +18,14 @@ document.addEventListener("DOMContentLoaded", function () {
         dashboardLink.classList.add("active");
     }
 
+    // Handle sign-out button click
+    const signOutButton = document.getElementById('sign-out-button');
+    signOutButton?.addEventListener('click', () => {
+        sessionStorage.clear();
+        localStorage.clear();
+        window.electronAPI.signOut();
+    });
+
     function addMenuEventListeners() {
         // Add click event listener to all menu items
         document.querySelectorAll(".menu-list").forEach((item) => {


### PR DESCRIPTION
## Summary
- Restore and enhance `sign-out` IPC handler to clear session data and reopen splash screen
- Expose `signOut` method in preload for renderer access
- Attach `#sign-out-button` click handler to trigger logout and wipe client storage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891551f9d748328a092a7dd55a58e08