### PR TITLE
feat: add auto-updater notifications

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -4,5 +4,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   sendLoginAttempt: (credentials) => ipcRenderer.send('login-attempt', credentials),
   onLoginResponse: (callback) => ipcRenderer.on('login-response', (event, response) => callback(response)),
-  onUserData: (callback) => ipcRenderer.on('user-data', (event, userData) => callback(userData))
+  onUserData: (callback) => ipcRenderer.on('user-data', (event, userData) => callback(userData)),
+  onUpdateMessage: (callback) => ipcRenderer.on('update-message', (event, message) => callback(message)),
+  onUpdateDownloaded: (callback) => ipcRenderer.on('update-downloaded', () => callback()),
+  restartApp: () => ipcRenderer.send('restart_app')
 });


### PR DESCRIPTION
## Summary
- add autoUpdater event handlers and restart prompt in main process
- expose update IPC APIs in preload script
- trigger update checks after app ready

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689152ea7c708328a955fe80882c3b2f