### PR TITLE
Use Express built-in request parsers

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,6 @@ const fs = require("fs");
 // SERVER ROUTES
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
-const bodyParser = require('body-parser');
 
 // Print userData path for debugging
 console.log('userData path:', app.getPath('userData'));
@@ -56,8 +55,8 @@ function startServer() {
   const PORT = process.env.PORT || 49200;
 
   // Middleware setup
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
 
 
   // API route for user authentication (login)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "bcrypt": "^5.1.1",
-    "body-parser": "^1.20.2",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
     "datatables.net": "^2.1.4",
@@ -59,20 +58,20 @@
     "electron-rebuild": "^3.2.9",
     "webpack-bundle-analyzer": "^4.10.2"
   },
-"build": {
-  "appId": "com.codecol.recordsmanagement",
-  "productName": "Records Management System",
-  "directories": {
-    "output": "dist"
-  },
-  "files": [
-    "dist/**/*",
-    "node_modules/**/*",
-    "main.js",
-    "index.html",
-    "package.json",
-    "database/**/*"
-  ],
+  "build": {
+    "appId": "com.codecol.recordsmanagement",
+    "productName": "Records Management System",
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "dist/**/*",
+      "node_modules/**/*",
+      "main.js",
+      "index.html",
+      "package.json",
+      "database/**/*"
+    ],
     "publish": [
       {
         "provider": "github",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
-const bodyParser = require('body-parser');
 const path = require('path');
 
 // Start Express server
@@ -19,8 +18,8 @@ function startServer() {
   });
 
   // Middleware setup
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
 
   // Define routes here
   app.get('/api/recent-entries', (req, res) => {


### PR DESCRIPTION
## Summary
- drop `body-parser` dependency
- switch Express setup to `express.json()` and `express.urlencoded()` in main and server scripts

## Testing
- `npm test` *(fails: no test specified)*
- `node server.js` then POSTed JSON and URL-encoded payloads to `/api/add-file`

------
https://chatgpt.com/codex/tasks/task_e_689152e511908328999295873d081eec