### PR TITLE
Guard DataTable initialization across sections

### DIFF
--- a/src/partials-public/entries/js/entries-renderer.js
+++ b/src/partials-public/entries/js/entries-renderer.js
@@ -30,6 +30,9 @@ $(document).ready(function () {
 });
 
 function initializeDataTableforEntries() {
+    if ($.fn.DataTable.isDataTable('#entries-table')) {
+        $('#entries-table').DataTable().destroy();
+    }
     const entriesTable = $('#entries-table').DataTable({
         "ajax": {
             "url": "http://localhost:49200/api/recent-entries-full",

--- a/src/partials-public/file-management/js/files-renderer.js
+++ b/src/partials-public/file-management/js/files-renderer.js
@@ -5,6 +5,9 @@ $(document).ready(function () {
 });
 
 function initializeDataTableforFiles() {
+    if ($.fn.DataTable.isDataTable('#file-table')) {
+        $('#file-table').DataTable().destroy();
+    }
     const filesTable = $('#file-table').DataTable({
         ajax: {
             url: "http://localhost:49200/api/get-files",

--- a/src/partials-public/letter-management/js/letters-renderer.js
+++ b/src/partials-public/letter-management/js/letters-renderer.js
@@ -4,6 +4,9 @@ $(document).ready(function () {
 });
 
 function initializeDataTableforLetters() {
+    if ($.fn.DataTable.isDataTable('#letters-table')) {
+        $('#letters-table').DataTable().destroy();
+    }
     const lettersTable = $('#letters-table').DataTable({
         ajax: {
             url: "http://localhost:49200/api/get-letters",


### PR DESCRIPTION
## Summary
- prevent double-initialization of Entries, Files, and Letters tables by destroying existing DataTables instances before re-creating them

## Testing
- `npm test` (fails: Error: no test specified)
- `node test-datatables.js` (fails: DataTables needs DOM, cannot read property 'length')

------
https://chatgpt.com/codex/tasks/task_e_689152e2b49483288745bff5e1f1e2aa