### PR TITLE
Fix /api/update-file: map optional fields and reorder SQL parameters

### DIFF
--- a/server.js
+++ b/server.js
@@ -211,8 +211,9 @@ function startServer() {
     }
 
     // Use null for optional fields if not provided
+    const recievedDateValue = recieved_date || null;
     const reciepientValue = reciepient || null;
-    const recievedDateValue = folio_number || null;
+    const folioNumberValue = folio_number || null;
     const descriptionValue = description || null;
 
     const query = `
@@ -227,11 +228,11 @@ function startServer() {
         file_number,
         subject,
         officer_assigned,
-        recieved_date,
-        date_sent,
-        file_type,
         recievedDateValue,
+        date_sent,
         reciepientValue,
+        file_type,
+        folioNumberValue,
         descriptionValue,
         status,
         entry_id,


### PR DESCRIPTION
### Motivation
- Correct an incorrect mapping and parameter ordering in the `/api/update-file` handler so optional fields are sourced and applied to the database correctly.
- Prevent updating the wrong columns when saving file entries by aligning JavaScript variables with their SQL placeholders.

### Description
- Add distinct optional-field variables `recievedDateValue`, `reciepientValue`, and `folioNumberValue` and source them from the correct request properties (`recieved_date`, `reciepient`, `folio_number`).
- Reorder the `db.run` parameter array to match the SQL `UPDATE` placeholder sequence: `entry_date, file_number, subject, officer_assigned, recieved_date, date_sent, reciepient, file_type, folio_number, description, status, entry_id`.
- Update `server.js` accordingly and commit the change.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f60d768c83288422a14ab4457691)