### PR TITLE
Require and sanitize user roles in user endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -533,9 +533,9 @@ function startServer() {
         return res.status(400).json({ error: validation.errors.join(", ") });
       }
 
-      // Sanitize inputs
-      const sanitizedUsername = sanitizeInput(username);
-      const sanitizedRole = sanitizeInput(user_role);
+      // Use validated and sanitized inputs
+      const sanitizedUsername = validation.sanitizedData.username;
+      const sanitizedRole = validation.sanitizedData.user_role;
 
       // Check if username already exists
       db.get(
@@ -599,14 +599,17 @@ function startServer() {
       const { username, password, user_role } = req.body;
 
       // Validate input data
-      const validation = validateUserData({ username, password, user_role });
+      const validation = validateUserData(
+        { username, password, user_role },
+        true
+      );
       if (!validation.isValid) {
         return res.status(400).json({ error: validation.errors.join(", ") });
       }
 
-      // Sanitize inputs
-      const sanitizedUsername = sanitizeInput(username);
-      const sanitizedRole = sanitizeInput(user_role);
+      // Use validated and sanitized inputs
+      const sanitizedUsername = validation.sanitizedData.username;
+      const sanitizedRole = validation.sanitizedData.user_role;
 
       // Check if user exists
       db.get(

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -257,6 +257,8 @@ function validateUserData(userData, isUpdate = false) {
       // Preserve the original role value as stored in the database
       sanitizedData.user_role = sanitizedRole;
     }
+  } else {
+    errors.push("User role is required");
   }
 
   return {


### PR DESCRIPTION
### Motivation
- Ensure `user_role` is always present and valid when creating or updating users so handlers don't operate on an undefined role.
- Avoid double/unsafe sanitization by using validated/sanitized values produced by the validation layer instead of calling `sanitizeInput` on raw request data.

### Description
- Make `user_role` required in `validateUserData` and add an error when it is missing, while continuing to validate and populate `sanitizedData.user_role` when provided.
- Update the POST `/api/users` handler to use `validation.sanitizedData.username` and `validation.sanitizedData.user_role` instead of calling `sanitizeInput` on raw values.
- Update the PUT `/api/users/:userId` handler to call `validateUserData(..., true)` (update mode) and use `validation.sanitizedData` for `username` and `user_role` so password validation remains optional and role is only updated when validated.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f65bfdbc83288435e2d4dd417265)